### PR TITLE
Add option to keep the plot window open when the main window is minimized

### DIFF
--- a/GUI/MainForm.Designer.cs
+++ b/GUI/MainForm.Designer.cs
@@ -82,6 +82,7 @@ namespace OpenHardwareMonitor.GUI {
       this.fahrenheitMenuItem = new System.Windows.Forms.MenuItem();
       this.plotLocationMenuItem = new System.Windows.Forms.MenuItem();
       this.plotWindowMenuItem = new System.Windows.Forms.MenuItem();
+      this.plotWindowIndepMenuItem = new System.Windows.Forms.MenuItem();
       this.plotBottomMenuItem = new System.Windows.Forms.MenuItem();
       this.plotRightMenuItem = new System.Windows.Forms.MenuItem();
       this.webMenuItemSeparator = new System.Windows.Forms.MenuItem();
@@ -429,6 +430,7 @@ namespace OpenHardwareMonitor.GUI {
       this.plotLocationMenuItem.Index = 6;
       this.plotLocationMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
             this.plotWindowMenuItem,
+            this.plotWindowIndepMenuItem,
             this.plotBottomMenuItem,
             this.plotRightMenuItem});
       this.plotLocationMenuItem.Text = "Plot Location";
@@ -438,16 +440,21 @@ namespace OpenHardwareMonitor.GUI {
       this.plotWindowMenuItem.Index = 0;
       this.plotWindowMenuItem.RadioCheck = true;
       this.plotWindowMenuItem.Text = "Window";
+      // plotWindowIndepMenuItem
+      // 
+      this.plotWindowIndepMenuItem.Index = 1;
+      this.plotWindowIndepMenuItem.RadioCheck = true;
+      this.plotWindowIndepMenuItem.Text = "Window indep.";
       // 
       // plotBottomMenuItem
       // 
-      this.plotBottomMenuItem.Index = 1;
+      this.plotBottomMenuItem.Index = 2;
       this.plotBottomMenuItem.RadioCheck = true;
       this.plotBottomMenuItem.Text = "Bottom";
       // 
       // plotRightMenuItem
       // 
-      this.plotRightMenuItem.Index = 2;
+      this.plotRightMenuItem.Index = 3;
       this.plotRightMenuItem.RadioCheck = true;
       this.plotRightMenuItem.Text = "Right";
       // 
@@ -735,6 +742,7 @@ namespace OpenHardwareMonitor.GUI {
     private System.Windows.Forms.MenuItem menuItem6;
     private System.Windows.Forms.MenuItem plotLocationMenuItem;
     private System.Windows.Forms.MenuItem plotWindowMenuItem;
+    private System.Windows.Forms.MenuItem plotWindowIndepMenuItem;
     private System.Windows.Forms.MenuItem plotBottomMenuItem;
     private System.Windows.Forms.MenuItem plotRightMenuItem;
 		private System.Windows.Forms.MenuItem webMenuItem;

--- a/GUI/MainForm.cs
+++ b/GUI/MainForm.cs
@@ -350,15 +350,16 @@ namespace OpenHardwareMonitor.GUI {
 
       showPlot = new UserOption("plotMenuItem", false, plotMenuItem, settings);
       plotLocation = new UserRadioGroup("plotLocation", 0,
-        new[] { plotWindowMenuItem, plotBottomMenuItem, plotRightMenuItem },
+        new[] { plotWindowMenuItem, plotWindowIndepMenuItem, plotBottomMenuItem, plotRightMenuItem },
         settings);
 
       showPlot.Changed += delegate(object sender, EventArgs e) {
-        if (plotLocation.Value == 0) {
+        if (plotLocation.Value <= 1)
+        {
           if (showPlot.Value && this.Visible)
             plotForm.Show();
           else
-            plotForm.Hide();
+            plotForm.Hide(); // only non independent window
         } else {
           splitContainer.Panel2Collapsed = !showPlot.Value;
         }
@@ -366,21 +367,22 @@ namespace OpenHardwareMonitor.GUI {
       };
       plotLocation.Changed += delegate(object sender, EventArgs e) {
         switch (plotLocation.Value) {
-          case 0:
+          case 0: // Window
+          case 1: // Window Indep.
             splitContainer.Panel2.Controls.Clear();
             splitContainer.Panel2Collapsed = true;
             plotForm.Controls.Add(plotPanel);
             if (showPlot.Value && this.Visible)
               plotForm.Show();
             break;
-          case 1:
+          case 2: // Bottom
             plotForm.Controls.Clear();
             plotForm.Hide();
             splitContainer.Orientation = Orientation.Horizontal;
             splitContainer.Panel2.Controls.Add(plotPanel);
             splitContainer.Panel2Collapsed = !showPlot.Value;
             break;
-          case 2:
+          case 3: // Right
             plotForm.Controls.Clear();
             plotForm.Hide();
             splitContainer.Orientation = Orientation.Vertical;
@@ -393,7 +395,7 @@ namespace OpenHardwareMonitor.GUI {
       plotForm.FormClosing += delegate(object sender, FormClosingEventArgs e) {
         if (e.CloseReason == CloseReason.UserClosing) {
           // just switch off the plotting when the user closes the form
-          if (plotLocation.Value == 0) {
+          if (plotLocation.Value <= 1){
             showPlot.Value = false;
           }
           e.Cancel = true;
@@ -425,10 +427,11 @@ namespace OpenHardwareMonitor.GUI {
       };
 
       this.VisibleChanged += delegate(object sender, EventArgs e) {
-        if (this.Visible && showPlot.Value && plotLocation.Value == 0)
+        if (this.Visible && showPlot.Value && plotLocation.Value <= 1)
           plotForm.Show();
         else
-          plotForm.Hide();
+          if(plotLocation.Value == 0)
+            plotForm.Hide();
       };
     }
 


### PR DESCRIPTION
Hi,
I've added an option to make the plot window more independent from the main window:
If  the option "Plot location->Window indep." is selected, minimizing the main window does not minimize the plot window. So you can keep only the plot window open to better utilize your screen estate.
How you see this as useful as I.
Regards,
Daniel