### PR TITLE
Prevent plot from reusing line colors if possible

### DIFF
--- a/GUI/MainForm.cs
+++ b/GUI/MainForm.cs
@@ -501,6 +501,27 @@ namespace OpenHardwareMonitor.GUI {
           colorIndex++;
         }
       }
+
+      //if a sensor is assigned a color that's already being used by another sensor,
+      //try to assign it a new color. This is done only after the previous loop
+      //sets an unchanging default color for all sensors, so that colors jump  
+      //around as little as possible as sensors get added/removed from the plot
+      List<Color> usedColors = new List<Color>();
+      foreach (var curSelectedSensor in selected) {
+          var curColor = colors[curSelectedSensor];
+          if (usedColors.Contains(curColor)) {
+              foreach (Color potentialNewColor in plotColorPalette) {
+                  if (!colors.Values.Contains(potentialNewColor)) {
+                      colors[curSelectedSensor] = potentialNewColor;
+                      usedColors.Add(potentialNewColor);
+                      break;
+                  }
+              }
+          } else {
+              usedColors.Add(curColor);
+          }
+      }  
+
       sensorPlotColors = colors;
       plotPanel.SetSensors(selected, colors);
     }


### PR DESCRIPTION
CURRENTLY: the code that sets plot line colors loops determines a
default color for the all sensors, such that, AFAIK, a given sensor will
always get the same plot color across different runs of the application
(as long as the list of all detected sensors stays the same). This
consistency is nice, but there's no duplicate handling so if the user is
unlucky they can end up with duplicate colors in their plot even when
the plot only contains 2 sensors.

MY CHANGE: I added a second step that attempts to find a new color for
sensors in the plot whose color is being used by another sensor.
However, I tried to keep as much of the old consistency as I could, so
the default color for each sensor is still calculated in the same way as
before. That way if there aren't any duplicate colors, all sensors will
keep the same color they had before the change, so I'm guessing most
users won't even notice the change.
That said, in certain circumstances this change can cause plot colors to
jump around a bit as sensors get added/removed from the plot. For
Example, if sensors A & B have the same default color and you add both
to the plot, sensor B will get assigned a different color in order to
prevent a duplicate color. However if you then remove sensor A from the
plot, sensor B will suddenly revert to it's default color, which may
seem to the user like mysterious action at a distance. Should be rare
though.