### PR TITLE
Feature/fanprofiles

### DIFF
--- a/GUI/FanControlManager.cs
+++ b/GUI/FanControlManager.cs
@@ -1,0 +1,205 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+using OpenHardwareMonitor.Collections;
+using OpenHardwareMonitor.Hardware;
+
+namespace OpenHardwareMonitor.GUI
+{
+    /// <summary>
+    /// Provides CRUD operations on fan control profiles.
+    /// </summary>
+    public class FanControlManager
+    {
+        private readonly PersistentSettings settings;
+
+        private readonly IEnumerable<ISensor> fanControls;
+
+        private readonly ListSet<string> availableProfiles;
+
+        private const string AllProfiles = "AllFanProfiles";
+
+        private const string LoadedFanProfile = "LoadedFanProfile";
+
+        private const string ProfileDelimiter = ";";
+
+        public FanControlManager(PersistentSettings settings, IEnumerable<ISensor> fanControls)
+        {
+            this.settings = settings;
+            this.fanControls = fanControls;
+            this.availableProfiles = FindAllProfiles();
+            var lastProfile = FindLastLoadedProfile();
+            if (lastProfile != null)
+            {
+                LoadProfile(lastProfile);
+            }
+        }
+
+        /// <summary>
+        /// Returns value of LoadedFanProfile entry or null if none was found.
+        /// </summary>
+        private string FindLastLoadedProfile()
+        {
+            return settings.GetValue(LoadedFanProfile, null);
+        }
+
+        /// <summary>
+        /// List of all profile names.
+        /// </summary>
+        public IEnumerable<string> AvailableProfiles
+        {
+            get
+            {
+                return availableProfiles;
+            }
+        }
+
+        /// <summary>
+        /// Name of the loaded profile. Null if no profile is loaded.
+        /// </summary>
+        public string LoadedProfile { get; private set; }
+
+        /// <summary>
+        /// Returns profile names of all profiles found in the settings.
+        /// </summary>
+        private ListSet<string> FindAllProfiles()
+        {
+            var allProfileNames = settings.GetValue(AllProfiles, string.Empty);
+            var explodedProfiles = allProfileNames.Split(new []{ProfileDelimiter}, StringSplitOptions.RemoveEmptyEntries);
+
+            var profileSet = new ListSet<string>();
+            foreach (var profile in explodedProfiles)
+            {
+                profileSet.Add(profile);
+            }
+
+            return profileSet;
+        }
+
+        /// <summary>
+        /// Creates a new fan control profile with the currently active fan control values.
+        /// If a profile with the same name already exists, it will be overwritten.
+        /// The new profile will be part of the persistent settings.
+        /// </summary>
+        /// <param name="profileName">Name of the profile.</param>
+        /// <exception cref="ArgumentException">If invalid profile name.</exception>
+        public void SaveCurrentSettingsAsProfile(string profileName)
+        {
+            CheckProfileName(profileName);
+
+            availableProfiles.Add(profileName);
+            SaveAllProfileNames();
+            SaveProfileSettings(profileName);
+        }
+
+        /// <exception cref="ArgumentException">If profile name contains delimiter.</exception>
+        private void CheckProfileName(string profileName)
+        {
+            if (string.IsNullOrEmpty(profileName) || profileName.Contains(ProfileDelimiter))
+            {
+                throw new ArgumentException("profile name invalid");
+            }
+        }
+
+        /// <summary>
+        /// Saves all settings of all fan controls under given profile.
+        /// </summary>
+        private void SaveProfileSettings(string profileName)
+        {
+            foreach (var fanControl in fanControls)
+            {
+                if (fanControl.Value.HasValue)
+                {
+                    var settingKey = ValueSettingKey(profileName, fanControl);
+                    settings.SetValue(settingKey, fanControl.Value.Value);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Saves all profile names in persistent settings.
+        /// </summary>
+        private void SaveAllProfileNames()
+        {
+            var allProfiles = string.Join(ProfileDelimiter.ToString(), availableProfiles.ToArray());
+            settings.SetValue(AllProfiles, allProfiles);
+        }
+
+        /// <summary>
+        /// Loads fan control profile with given name and applies the settings.
+        /// Also sets the LoadedProfile property and the associated setting.
+        /// </summary>
+        /// <exception cref="ArgumentException">Thrown if profile name is invalid or no profile is found under the name.</exception>
+        public void LoadProfile(string profileName)
+        {
+            CheckProfileName(profileName);
+
+            foreach (var fanControl in fanControls)
+            {
+                var valueSettingKey = ValueSettingKey(profileName, fanControl);
+
+                var fanValue = settings.GetValue(valueSettingKey, -1.0f);
+                if (fanValue != -1)
+                {
+                    fanControl.Control.SetSoftware(fanValue);
+                }
+            }
+
+            LoadedProfile = profileName;
+            settings.SetValue(LoadedFanProfile, LoadedProfile);
+        }
+
+        /// <summary>
+        /// Returns key of value setting of a given fan.
+        /// </summary>
+        /// <example>profileName = "my profile" and fan = gpu will return "my profile.gpu".</example>
+        private string ValueSettingKey(string profileName, ISensor fan)
+        {
+            return profileName + "." + fan.Name;
+        }
+
+        /// <summary>
+        /// Deletes a profile from settings. Does not change any fan settings. 
+        /// If profileName == LoadedProfile, LoadedProfile will be null afterwards.
+        /// </summary>
+        /// <exception cref="ArgumentException">Thrown if profile name is invalid or no profile is found under the name.</exception>
+        public void DeleteProfile(string profileName)
+        {
+            CheckProfileName(profileName);
+
+            if (!availableProfiles.Contains(profileName))
+            {
+                throw new ArgumentException("no profile found");
+            }
+
+            if (profileName == LoadedProfile)
+            {
+                LoadedProfile = null;
+            }
+
+            availableProfiles.Remove(profileName);
+            SaveAllProfileNames();
+
+            foreach (var fanControl in fanControls)
+            {
+                var valueSettingKey = ValueSettingKey(profileName, fanControl);
+                settings.Remove(valueSettingKey);
+            }
+        }
+
+        /// <summary>
+        /// Overwrites the settings of the loaded profile with the current settings.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">If no profile is currently loaded.</exception>
+        public void UpdateLoadedProfileWithCurrentSettings()
+        {
+            if (LoadedProfile == null)
+            {
+                throw new InvalidOperationException("no profile loaded");
+            }
+
+            SaveCurrentSettingsAsProfile(LoadedProfile);
+        }
+    }
+}

--- a/GUI/MainForm.Designer.cs
+++ b/GUI/MainForm.Designer.cs
@@ -84,11 +84,31 @@ namespace OpenHardwareMonitor.GUI {
       this.plotWindowMenuItem = new System.Windows.Forms.MenuItem();
       this.plotBottomMenuItem = new System.Windows.Forms.MenuItem();
       this.plotRightMenuItem = new System.Windows.Forms.MenuItem();
+      this.logSeparatorMenuItem = new System.Windows.Forms.MenuItem();
+      this.logSensorsMenuItem = new System.Windows.Forms.MenuItem();
+      this.loggingIntervalMenuItem = new System.Windows.Forms.MenuItem();
+      this.log1sMenuItem = new System.Windows.Forms.MenuItem();
+      this.log2sMenuItem = new System.Windows.Forms.MenuItem();
+      this.log5sMenuItem = new System.Windows.Forms.MenuItem();
+      this.log10sMenuItem = new System.Windows.Forms.MenuItem();
+      this.log30sMenuItem = new System.Windows.Forms.MenuItem();
+      this.log1minMenuItem = new System.Windows.Forms.MenuItem();
+      this.log2minMenuItem = new System.Windows.Forms.MenuItem();
+      this.log5minMenuItem = new System.Windows.Forms.MenuItem();
+      this.log10minMenuItem = new System.Windows.Forms.MenuItem();
+      this.log30minMenuItem = new System.Windows.Forms.MenuItem();
+      this.log1hMenuItem = new System.Windows.Forms.MenuItem();
+      this.log2hMenuItem = new System.Windows.Forms.MenuItem();
+      this.log6hMenuItem = new System.Windows.Forms.MenuItem();
       this.webMenuItemSeparator = new System.Windows.Forms.MenuItem();
       this.webMenuItem = new System.Windows.Forms.MenuItem();
       this.runWebServerMenuItem = new System.Windows.Forms.MenuItem();
       this.serverPortMenuItem = new System.Windows.Forms.MenuItem();
-      this.logSensorsMenuItem = new System.Windows.Forms.MenuItem();
+      this.fanMenu = new System.Windows.Forms.MenuItem();
+      this.availableProfilesList = new System.Windows.Forms.MenuItem();
+      this.saveCurrentSettingsAsProfile = new System.Windows.Forms.MenuItem();
+      this.updateMenuButton = new System.Windows.Forms.MenuItem();
+      this.deleteProfilesList = new System.Windows.Forms.MenuItem();
       this.helpMenuItem = new System.Windows.Forms.MenuItem();
       this.aboutMenuItem = new System.Windows.Forms.MenuItem();
       this.treeContextMenu = new System.Windows.Forms.ContextMenu();
@@ -96,21 +116,6 @@ namespace OpenHardwareMonitor.GUI {
       this.timer = new System.Windows.Forms.Timer(this.components);
       this.splitContainer = new OpenHardwareMonitor.GUI.SplitContainerAdv();
       this.treeView = new Aga.Controls.Tree.TreeViewAdv();
-      this.logSeparatorMenuItem = new System.Windows.Forms.MenuItem();
-      this.loggingIntervalMenuItem = new System.Windows.Forms.MenuItem();
-      this.log1sMenuItem = new System.Windows.Forms.MenuItem();
-      this.log5sMenuItem = new System.Windows.Forms.MenuItem();
-      this.log10sMenuItem = new System.Windows.Forms.MenuItem();
-      this.log30sMenuItem = new System.Windows.Forms.MenuItem();
-      this.log1minMenuItem = new System.Windows.Forms.MenuItem();
-      this.log5minMenuItem = new System.Windows.Forms.MenuItem();
-      this.log10minMenuItem = new System.Windows.Forms.MenuItem();
-      this.log30minMenuItem = new System.Windows.Forms.MenuItem();
-      this.log2sMenuItem = new System.Windows.Forms.MenuItem();
-      this.log2minMenuItem = new System.Windows.Forms.MenuItem();
-      this.log1hMenuItem = new System.Windows.Forms.MenuItem();
-      this.log2hMenuItem = new System.Windows.Forms.MenuItem();
-      this.log6hMenuItem = new System.Windows.Forms.MenuItem();
       this.splitContainer.Panel1.SuspendLayout();
       this.splitContainer.SuspendLayout();
       this.SuspendLayout();
@@ -200,6 +205,7 @@ namespace OpenHardwareMonitor.GUI {
             this.fileMenuItem,
             this.viewMenuItem,
             this.optionsMenuItem,
+            this.fanMenu,
             this.helpMenuItem});
       // 
       // fileMenuItem
@@ -242,7 +248,7 @@ namespace OpenHardwareMonitor.GUI {
       // 
       this.menuItem5.Index = 4;
       this.menuItem5.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
-            this.mainboardMenuItem,
+      this.mainboardMenuItem,
             this.cpuMenuItem,
             this.ramMenuItem,
             this.gpuMenuItem,
@@ -295,13 +301,13 @@ namespace OpenHardwareMonitor.GUI {
       // 
       this.viewMenuItem.Index = 1;
       this.viewMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
-            this.resetMinMaxMenuItem,
-            this.MenuItem3,
-            this.hiddenMenuItem,
-            this.plotMenuItem,
-            this.gadgetMenuItem,
-            this.MenuItem1,
-            this.columnsMenuItem});
+      this.resetMinMaxMenuItem,
+      this.MenuItem3,
+      this.hiddenMenuItem,
+      this.plotMenuItem,
+      this.gadgetMenuItem,
+      this.MenuItem1,
+      this.columnsMenuItem});
       this.viewMenuItem.Text = "View";
       // 
       // resetMinMaxMenuItem
@@ -339,9 +345,9 @@ namespace OpenHardwareMonitor.GUI {
       // 
       this.columnsMenuItem.Index = 6;
       this.columnsMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
-            this.valueMenuItem,
-            this.minMenuItem,
-            this.maxMenuItem});
+      this.valueMenuItem,
+      this.minMenuItem,
+      this.maxMenuItem});
       this.columnsMenuItem.Text = "Columns";
       // 
       // valueMenuItem
@@ -363,18 +369,18 @@ namespace OpenHardwareMonitor.GUI {
       // 
       this.optionsMenuItem.Index = 2;
       this.optionsMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
-            this.startMinMenuItem,
-            this.minTrayMenuItem,
-            this.minCloseMenuItem,
-            this.startupMenuItem,
-            this.separatorMenuItem,
-            this.temperatureUnitsMenuItem,
-            this.plotLocationMenuItem,
-            this.logSeparatorMenuItem,
-            this.logSensorsMenuItem,
-            this.loggingIntervalMenuItem,
-            this.webMenuItemSeparator,
-            this.webMenuItem});
+      this.startMinMenuItem,
+      this.minTrayMenuItem,
+      this.minCloseMenuItem,
+      this.startupMenuItem,
+      this.separatorMenuItem,
+      this.temperatureUnitsMenuItem,
+      this.plotLocationMenuItem,
+      this.logSeparatorMenuItem,
+      this.logSensorsMenuItem,
+      this.loggingIntervalMenuItem,
+      this.webMenuItemSeparator,
+      this.webMenuItem});
       this.optionsMenuItem.Text = "Options";
       // 
       // startMinMenuItem
@@ -406,8 +412,8 @@ namespace OpenHardwareMonitor.GUI {
       // 
       this.temperatureUnitsMenuItem.Index = 5;
       this.temperatureUnitsMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
-            this.celsiusMenuItem,
-            this.fahrenheitMenuItem});
+      this.celsiusMenuItem,
+      this.fahrenheitMenuItem});
       this.temperatureUnitsMenuItem.Text = "Temperature Unit";
       // 
       // celsiusMenuItem
@@ -428,9 +434,9 @@ namespace OpenHardwareMonitor.GUI {
       // 
       this.plotLocationMenuItem.Index = 6;
       this.plotLocationMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
-            this.plotWindowMenuItem,
-            this.plotBottomMenuItem,
-            this.plotRightMenuItem});
+      this.plotWindowMenuItem,
+      this.plotBottomMenuItem,
+      this.plotRightMenuItem});
       this.plotLocationMenuItem.Text = "Plot Location";
       // 
       // plotWindowMenuItem
@@ -451,6 +457,113 @@ namespace OpenHardwareMonitor.GUI {
       this.plotRightMenuItem.RadioCheck = true;
       this.plotRightMenuItem.Text = "Right";
       // 
+      // logSeparatorMenuItem
+      // 
+      this.logSeparatorMenuItem.Index = 7;
+      this.logSeparatorMenuItem.Text = "-";
+      // 
+      // logSensorsMenuItem
+      // 
+      this.logSensorsMenuItem.Index = 8;
+      this.logSensorsMenuItem.Text = "Log Sensors";
+      // 
+      // loggingIntervalMenuItem
+      // 
+      this.loggingIntervalMenuItem.Index = 9;
+      this.loggingIntervalMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
+      this.log1sMenuItem,
+      this.log2sMenuItem,
+      this.log5sMenuItem,
+      this.log10sMenuItem,
+      this.log30sMenuItem,
+      this.log1minMenuItem,
+      this.log2minMenuItem,
+      this.log5minMenuItem,
+      this.log10minMenuItem,
+      this.log30minMenuItem,
+      this.log1hMenuItem,
+      this.log2hMenuItem,
+      this.log6hMenuItem});
+      this.loggingIntervalMenuItem.Text = "Logging Interval";
+      // 
+      // log1sMenuItem
+      // 
+      this.log1sMenuItem.Index = 0;
+      this.log1sMenuItem.RadioCheck = true;
+      this.log1sMenuItem.Text = "1s";
+      // 
+      // log2sMenuItem
+      // 
+      this.log2sMenuItem.Index = 1;
+      this.log2sMenuItem.RadioCheck = true;
+      this.log2sMenuItem.Text = "2s";
+      // 
+      // log5sMenuItem
+      // 
+      this.log5sMenuItem.Index = 2;
+      this.log5sMenuItem.RadioCheck = true;
+      this.log5sMenuItem.Text = "5s";
+      // 
+      // log10sMenuItem
+      // 
+      this.log10sMenuItem.Index = 3;
+      this.log10sMenuItem.RadioCheck = true;
+      this.log10sMenuItem.Text = "10s";
+      // 
+      // log30sMenuItem
+      // 
+      this.log30sMenuItem.Index = 4;
+      this.log30sMenuItem.RadioCheck = true;
+      this.log30sMenuItem.Text = "30s";
+      // 
+      // log1minMenuItem
+      // 
+      this.log1minMenuItem.Index = 5;
+      this.log1minMenuItem.RadioCheck = true;
+      this.log1minMenuItem.Text = "1min";
+      // 
+      // log2minMenuItem
+      // 
+      this.log2minMenuItem.Index = 6;
+      this.log2minMenuItem.RadioCheck = true;
+      this.log2minMenuItem.Text = "2min";
+      // 
+      // log5minMenuItem
+      // 
+      this.log5minMenuItem.Index = 7;
+      this.log5minMenuItem.RadioCheck = true;
+      this.log5minMenuItem.Text = "5min";
+      // 
+      // log10minMenuItem
+      // 
+      this.log10minMenuItem.Index = 8;
+      this.log10minMenuItem.RadioCheck = true;
+      this.log10minMenuItem.Text = "10min";
+      // 
+      // log30minMenuItem
+      // 
+      this.log30minMenuItem.Index = 9;
+      this.log30minMenuItem.RadioCheck = true;
+      this.log30minMenuItem.Text = "30min";
+      // 
+      // log1hMenuItem
+      // 
+      this.log1hMenuItem.Index = 10;
+      this.log1hMenuItem.RadioCheck = true;
+      this.log1hMenuItem.Text = "1h";
+      // 
+      // log2hMenuItem
+      // 
+      this.log2hMenuItem.Index = 11;
+      this.log2hMenuItem.RadioCheck = true;
+      this.log2hMenuItem.Text = "2h";
+      // 
+      // log6hMenuItem
+      // 
+      this.log6hMenuItem.Index = 12;
+      this.log6hMenuItem.RadioCheck = true;
+      this.log6hMenuItem.Text = "6h";
+      // 
       // webMenuItemSeparator
       // 
       this.webMenuItemSeparator.Index = 10;
@@ -460,8 +573,8 @@ namespace OpenHardwareMonitor.GUI {
       // 
       this.webMenuItem.Index = 11;
       this.webMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
-            this.runWebServerMenuItem,
-            this.serverPortMenuItem});
+      this.runWebServerMenuItem,
+      this.serverPortMenuItem});
       this.webMenuItem.Text = "Remote Web Server";
       // 
       // runWebServerMenuItem
@@ -475,16 +588,43 @@ namespace OpenHardwareMonitor.GUI {
       this.serverPortMenuItem.Text = "Port";
       this.serverPortMenuItem.Click += new System.EventHandler(this.serverPortMenuItem_Click);
       // 
-      // logSensorsMenuItem
+      // fanMenu
       // 
-      this.logSensorsMenuItem.Index = 8;
-      this.logSensorsMenuItem.Text = "Log Sensors";
+      this.fanMenu.Index = 3;
+      this.fanMenu.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
+      this.availableProfilesList,
+      this.saveCurrentSettingsAsProfile,
+      this.updateMenuButton,
+      this.deleteProfilesList});
+      this.fanMenu.Text = "Fan";
+      // 
+      // availableProfilesList
+      // 
+      this.availableProfilesList.Index = 0;
+      this.availableProfilesList.Text = "Profiles";
+      // 
+      // saveCurrentSettingsAsProfile
+      // 
+      this.saveCurrentSettingsAsProfile.Index = 1;
+      this.saveCurrentSettingsAsProfile.Text = "Create";
+      this.saveCurrentSettingsAsProfile.Click += new System.EventHandler(this.saveCurrentSettingsAsProfile_Click);
+      // 
+      // updateMenuButton
+      // 
+      this.updateMenuButton.Index = 2;
+      this.updateMenuButton.Text = "Update";
+      this.updateMenuButton.Click += new System.EventHandler(this.updateMenuButton_Click);
+      // 
+      // deleteProfilesList
+      // 
+      this.deleteProfilesList.Index = 3;
+      this.deleteProfilesList.Text = "Delete";
       // 
       // helpMenuItem
       // 
-      this.helpMenuItem.Index = 3;
+      this.helpMenuItem.Index = 4;
       this.helpMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
-            this.aboutMenuItem});
+      this.aboutMenuItem});
       this.helpMenuItem.Text = "Help";
       // 
       // aboutMenuItem
@@ -561,108 +701,6 @@ namespace OpenHardwareMonitor.GUI {
       this.treeView.MouseMove += new System.Windows.Forms.MouseEventHandler(this.treeView_MouseMove);
       this.treeView.MouseUp += new System.Windows.Forms.MouseEventHandler(this.treeView_MouseUp);
       // 
-      // logSeparatorMenuItem
-      // 
-      this.logSeparatorMenuItem.Index = 7;
-      this.logSeparatorMenuItem.Text = "-";
-      // 
-      // loggingIntervalMenuItem
-      // 
-      this.loggingIntervalMenuItem.Index = 9;
-      this.loggingIntervalMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
-            this.log1sMenuItem,
-            this.log2sMenuItem,
-            this.log5sMenuItem,
-            this.log10sMenuItem,
-            this.log30sMenuItem,
-            this.log1minMenuItem,
-            this.log2minMenuItem,
-            this.log5minMenuItem,
-            this.log10minMenuItem,
-            this.log30minMenuItem,
-            this.log1hMenuItem,
-            this.log2hMenuItem,
-            this.log6hMenuItem});
-      this.loggingIntervalMenuItem.Text = "Logging Interval";
-      // 
-      // log1sMenuItem
-      // 
-      this.log1sMenuItem.Index = 0;
-      this.log1sMenuItem.RadioCheck = true;
-      this.log1sMenuItem.Text = "1s";
-      // 
-      // log5sMenuItem
-      // 
-      this.log5sMenuItem.Index = 2;
-      this.log5sMenuItem.RadioCheck = true;
-      this.log5sMenuItem.Text = "5s";
-      // 
-      // log10sMenuItem
-      // 
-      this.log10sMenuItem.Index = 3;
-      this.log10sMenuItem.RadioCheck = true;
-      this.log10sMenuItem.Text = "10s";
-      // 
-      // log30sMenuItem
-      // 
-      this.log30sMenuItem.Index = 4;
-      this.log30sMenuItem.RadioCheck = true;
-      this.log30sMenuItem.Text = "30s";
-      // 
-      // log1minMenuItem
-      // 
-      this.log1minMenuItem.Index = 5;
-      this.log1minMenuItem.RadioCheck = true;
-      this.log1minMenuItem.Text = "1min";
-      // 
-      // log5minMenuItem
-      // 
-      this.log5minMenuItem.Index = 7;
-      this.log5minMenuItem.RadioCheck = true;
-      this.log5minMenuItem.Text = "5min";
-      // 
-      // log10minMenuItem
-      // 
-      this.log10minMenuItem.Index = 8;
-      this.log10minMenuItem.RadioCheck = true;
-      this.log10minMenuItem.Text = "10min";
-      // 
-      // log30minMenuItem
-      // 
-      this.log30minMenuItem.Index = 9;
-      this.log30minMenuItem.RadioCheck = true;
-      this.log30minMenuItem.Text = "30min";
-      // 
-      // log2sMenuItem
-      // 
-      this.log2sMenuItem.Index = 1;
-      this.log2sMenuItem.RadioCheck = true;
-      this.log2sMenuItem.Text = "2s";
-      // 
-      // log2minMenuItem
-      // 
-      this.log2minMenuItem.Index = 6;
-      this.log2minMenuItem.RadioCheck = true;
-      this.log2minMenuItem.Text = "2min";
-      // 
-      // log1hMenuItem
-      // 
-      this.log1hMenuItem.Index = 10;
-      this.log1hMenuItem.RadioCheck = true;
-      this.log1hMenuItem.Text = "1h";
-      // 
-      // log2hMenuItem
-      // 
-      this.log2hMenuItem.Index = 11;
-      this.log2hMenuItem.RadioCheck = true;
-      this.log2hMenuItem.Text = "2h";
-      // 
-      // log6hMenuItem
-      // 
-      this.log6hMenuItem.Index = 12;
-      this.log6hMenuItem.RadioCheck = true;
-      this.log6hMenuItem.Text = "6h";
-      // 
       // MainForm
       // 
       this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -737,7 +775,7 @@ namespace OpenHardwareMonitor.GUI {
     private System.Windows.Forms.MenuItem plotWindowMenuItem;
     private System.Windows.Forms.MenuItem plotBottomMenuItem;
     private System.Windows.Forms.MenuItem plotRightMenuItem;
-		private System.Windows.Forms.MenuItem webMenuItem;
+	private System.Windows.Forms.MenuItem webMenuItem;
     private System.Windows.Forms.MenuItem runWebServerMenuItem;
     private System.Windows.Forms.MenuItem serverPortMenuItem;
     private System.Windows.Forms.MenuItem menuItem5;
@@ -762,6 +800,11 @@ namespace OpenHardwareMonitor.GUI {
     private System.Windows.Forms.MenuItem log1hMenuItem;
     private System.Windows.Forms.MenuItem log2hMenuItem;
     private System.Windows.Forms.MenuItem log6hMenuItem;
-  }
+    private System.Windows.Forms.MenuItem fanMenu;
+    private System.Windows.Forms.MenuItem saveCurrentSettingsAsProfile;
+    private System.Windows.Forms.MenuItem availableProfilesList;
+    private System.Windows.Forms.MenuItem updateMenuButton;
+    private System.Windows.Forms.MenuItem deleteProfilesList;
+    }
 }
 

--- a/GUI/MainForm.cs
+++ b/GUI/MainForm.cs
@@ -16,6 +16,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Drawing;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Windows.Forms;
 using Aga.Controls.Tree;
@@ -26,6 +27,7 @@ using OpenHardwareMonitor.Utilities;
 
 namespace OpenHardwareMonitor.GUI {
   public partial class MainForm : Form {
+    private FanControlManager fanControlManager;
 
     private PersistentSettings settings;
     private UnitManager unitManager;
@@ -333,6 +335,19 @@ namespace OpenHardwareMonitor.GUI {
         if (runWebServer.Value) 
           server.Quit();
       };
+
+      var fanControls = treeView.AllNodes
+            .Select(node => node.Tag)
+            .OfType<SensorNode>()
+            .Select(node => node.Sensor)
+            .Where(sensor => sensor.SensorType == SensorType.Control)
+            .ToList();
+
+      fanControlManager = new FanControlManager(settings, fanControls);
+
+      ReloadProfileList(availableProfilesList.MenuItems, LoadSelectedProfile);
+      ReloadProfileList(deleteProfilesList.MenuItems, DeleteSelectedProfile);
+      CheckLoadedProfile();
     }
 
     private void InitializePlotForm() {
@@ -876,6 +891,88 @@ namespace OpenHardwareMonitor.GUI {
     public HttpServer Server {
       get { return server; }
     }
+        
+    private void saveCurrentSettingsAsProfile_Click(object sender, EventArgs e)
+    {
+      var profileNameBox = new StringInputBox
+                               {
+                                   Title = "Profile Name", PromptMessage = "Profile Name:",
+                                   IsValidInput = input => !input.Contains(";"),
+                                   StartPosition = FormStartPosition.CenterParent
+                               };
+      profileNameBox.ShowDialog();
 
-  }
+      if (!profileNameBox.Accepted)
+      {
+          return;
+      }
+
+      var profileName = profileNameBox.UserInput;
+
+      fanControlManager.SaveCurrentSettingsAsProfile(profileName);
+      fanControlManager.LoadProfile(profileName);
+
+      ReloadProfileList(availableProfilesList.MenuItems, LoadSelectedProfile);
+      ReloadProfileList(deleteProfilesList.MenuItems, DeleteSelectedProfile);
+      CheckLoadedProfile();
+    }
+
+    /// <summary>
+    /// Deletes selected profile.
+    /// </summary>
+    private void DeleteSelectedProfile(object sender, EventArgs e)
+    {
+      var profileName = ((MenuItem)sender).Text;
+      fanControlManager.DeleteProfile(profileName);
+
+      ReloadProfileList(availableProfilesList.MenuItems, LoadSelectedProfile);
+      ReloadProfileList(deleteProfilesList.MenuItems, DeleteSelectedProfile);
+
+      CheckLoadedProfile();
+    }
+
+    /// <summary>
+    /// Reloads the list of available profiles. Clears and then appends the list to collectionDestination.
+    /// </summary>
+    private void ReloadProfileList(Menu.MenuItemCollection collectionDestination, EventHandler itemClickHandler)
+    {
+      collectionDestination.Clear();
+
+      foreach (var profile in fanControlManager.AvailableProfiles)
+      {
+          var profileItem = collectionDestination.Add(profile);
+          profileItem.Click += itemClickHandler;
+      }
+    }
+
+    /// <summary>
+    /// Sets checkmark next to loaded profile and clears all other checkmarks.
+    /// </summary>
+    private void CheckLoadedProfile()
+    {
+      foreach (var profile in availableProfilesList.MenuItems.Cast<MenuItem>())
+      {
+          profile.Checked = profile.Text == fanControlManager.LoadedProfile;
+      }
+    }
+
+    /// <summary>
+    /// Loads a profile and sets checkmark.
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="eventArgs"></param>
+    private void LoadSelectedProfile(object sender, EventArgs eventArgs)
+    {
+      var profileItem = (MenuItem)sender;
+      var profileName = profileItem.Text;
+      fanControlManager.LoadProfile(profileName);
+
+      CheckLoadedProfile();
+    }
+
+    private void updateMenuButton_Click(object sender, EventArgs e)
+    {
+      fanControlManager.UpdateLoadedProfileWithCurrentSettings();
+    }
+    }
 }

--- a/GUI/StringInputBox.Designer.cs
+++ b/GUI/StringInputBox.Designer.cs
@@ -1,0 +1,101 @@
+﻿namespace OpenHardwareMonitor.GUI
+{
+    partial class StringInputBox
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.okButton = new System.Windows.Forms.Button();
+            this.cancelButton = new System.Windows.Forms.Button();
+            this.promptMessageLabel = new System.Windows.Forms.Label();
+            this.inputBox = new System.Windows.Forms.TextBox();
+            this.SuspendLayout();
+            // 
+            // okButton
+            // 
+            this.okButton.Location = new System.Drawing.Point(111, 79);
+            this.okButton.Name = "okButton";
+            this.okButton.Size = new System.Drawing.Size(75, 23);
+            this.okButton.TabIndex = 0;
+            this.okButton.Text = "OK";
+            this.okButton.UseVisualStyleBackColor = true;
+            this.okButton.Click += new System.EventHandler(this.okButton_Click);
+            // 
+            // cancelButton
+            // 
+            this.cancelButton.Location = new System.Drawing.Point(192, 79);
+            this.cancelButton.Name = "cancelButton";
+            this.cancelButton.Size = new System.Drawing.Size(75, 23);
+            this.cancelButton.TabIndex = 1;
+            this.cancelButton.Text = "Cancel";
+            this.cancelButton.UseVisualStyleBackColor = true;
+            this.cancelButton.Click += new System.EventHandler(this.cancelButton_Click);
+            // 
+            // promptMessageLabel
+            // 
+            this.promptMessageLabel.AutoSize = true;
+            this.promptMessageLabel.Location = new System.Drawing.Point(7, 9);
+            this.promptMessageLabel.Name = "promptMessageLabel";
+            this.promptMessageLabel.Size = new System.Drawing.Size(34, 13);
+            this.promptMessageLabel.TabIndex = 2;
+            this.promptMessageLabel.Text = "Input:";
+            // 
+            // inputBox
+            // 
+            this.inputBox.Location = new System.Drawing.Point(10, 36);
+            this.inputBox.Name = "inputBox";
+            this.inputBox.Size = new System.Drawing.Size(257, 20);
+            this.inputBox.TabIndex = 3;
+            // 
+            // StringInputBox
+            // 
+            this.AcceptButton = this.okButton;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoSize = true;
+            this.CancelButton = this.cancelButton;
+            this.ClientSize = new System.Drawing.Size(279, 114);
+            this.Controls.Add(this.inputBox);
+            this.Controls.Add(this.promptMessageLabel);
+            this.Controls.Add(this.cancelButton);
+            this.Controls.Add(this.okButton);
+            this.MaximizeBox = false;
+            this.Name = "StringInputBox";
+            this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
+            this.Text = "StringInputBox";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Button okButton;
+        private System.Windows.Forms.Button cancelButton;
+        private System.Windows.Forms.Label promptMessageLabel;
+        private System.Windows.Forms.TextBox inputBox;
+    }
+}

--- a/GUI/StringInputBox.cs
+++ b/GUI/StringInputBox.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Windows.Forms;
+
+namespace OpenHardwareMonitor.GUI
+{
+    public partial class StringInputBox : Form
+    {
+        public StringInputBox()
+        {
+            InitializeComponent();
+
+            Activated += (sender, args) => inputBox.Focus();
+        }
+
+        public string Title
+        {
+            get
+            {
+                return Text;
+            }
+
+            set
+            {
+                Text = value;
+            }
+        }
+
+        public string PromptMessage
+        {
+            get
+            {
+                return promptMessageLabel.Text;
+            }
+
+            set
+            {
+                promptMessageLabel.Text = value;
+            }
+        }
+
+        public string UserInput
+        {
+            get
+            {
+                return inputBox.Text;
+            }
+        }
+
+        public Func<string, bool> IsValidInput { get; set; }
+
+        public bool Accepted { get; private set; }
+
+        private void okButton_Click(object sender, EventArgs e)
+        {
+            if (IsValidInput != null && !IsValidInput(UserInput))
+            {
+                MessageBox.Show("Invalid input.", "Invalid input.", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            Accepted = true;
+            Close();
+        }
+
+        private void cancelButton_Click(object sender, EventArgs e)
+        {
+            Accepted = false;
+            Close();
+        }
+    }
+}

--- a/GUI/StringInputBox.resx
+++ b/GUI/StringInputBox.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/OpenHardwareMonitor.csproj
+++ b/OpenHardwareMonitor.csproj
@@ -114,6 +114,12 @@
     <Compile Include="GUI\SplitContainerAdv.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="GUI\StringInputBox.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="GUI\StringInputBox.Designer.cs">
+      <DependentUpon>StringInputBox.cs</DependentUpon>
+    </Compile>
     <Compile Include="GUI\SystemTray.cs" />
     <Compile Include="GUI\StartupManager.cs" />
     <Compile Include="GUI\TaskScheduler.cs" />
@@ -159,6 +165,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="GUI\PortForm.resx">
       <DependentUpon>PortForm.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="GUI\StringInputBox.resx">
+      <DependentUpon>StringInputBox.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Resources\ati.png">
     </EmbeddedResource>

--- a/OpenHardwareMonitor.csproj
+++ b/OpenHardwareMonitor.csproj
@@ -76,6 +76,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GUI\FanControlManager.cs" />
     <Compile Include="GUI\GadgetWindow.cs" />
     <Compile Include="GUI\Gadget.cs" />
     <Compile Include="GUI\HardwareTypeImage.cs" />


### PR DESCRIPTION
This is a simple feature that allows you to manage profiles for fan speed. E.g., users whose fans do not adjust themselves automatically may want to create a quiet and a full speed profile and choose the first one for normal operations and the second one for gaming.

You can create, switch, update and delete profiles.
All profile settings and profile selection are persisted and restored on startup.
