### PR TITLE
Fixing unhandled exception in GetTempFileName

### DIFF
--- a/Hardware/Ring0.cs
+++ b/Hardware/Ring0.cs
@@ -48,14 +48,15 @@ namespace OpenHardwareMonitor.Hardware {
     private static string GetTempFileName() {
       
       // try to create one in the application folder
-      string fileName = Path.ChangeExtension(
-        Assembly.GetEntryAssembly().Location, ".sys");
       try {
-        using (FileStream stream = File.Create(fileName)) {
+		string fileName = Path.ChangeExtension(
+			Assembly.GetEntryAssembly().Location, ".sys");
+		using (FileStream stream = File.Create(fileName)) {
           return fileName;
         }        
       } catch (IOException) { } 
         catch (UnauthorizedAccessException) { }
+		catch (Exception) { }
 
       // if this failed, try to get a file in the temporary folder
       try {


### PR DESCRIPTION
Assembly.GetEntryAssembly().Location may return null if we loaded from an unmanaged application (https://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k(System.Reflection.Assembly.GetEntryAssembly);k(TargetFrameworkMoniker-.NETFramework,Version%3Dv2.0);k(DevLang-csharp)&rd=true). In this case ring0 driver cannot start on win10 at least.