### PR TITLE
Samsung SSD statistics updated

### DIFF
--- a/Hardware/HDD/SSDPlextor.cs
+++ b/Hardware/HDD/SSDPlextor.cs
@@ -8,20 +8,30 @@
 	
 */
 
-namespace OpenHardwareMonitor.Hardware.HDD {
-  using System.Collections.Generic;
+using OpenHardwareMonitor.Collections;
 
-  [NamePrefix("PLEXTOR")]
+namespace OpenHardwareMonitor.Hardware.HDD
+{
+    using System.Collections.Generic;
+
+    [NamePrefix("PLEXTOR")]
   internal class SSDPlextor : AbstractHarddrive {
 
     private static readonly IEnumerable<SmartAttribute> smartAttributes =
       new List<SmartAttribute> {
       new SmartAttribute(0x09, SmartNames.PowerOnHours, RawToInt),
       new SmartAttribute(0x0C, SmartNames.PowerCycleCount, RawToInt),
+      new SmartAttribute(0xF1, SmartNames.HostWrites, RawToGb, SensorType.Data, 0, SmartNames.HostWrites),
+      new SmartAttribute(0xF2, SmartNames.HostReads, RawToGb, SensorType.Data, 1, SmartNames.HostReads),
     };
 
-    public SSDPlextor(ISmart smart, string name, string firmwareRevision, 
+        public SSDPlextor(ISmart smart, string name, string firmwareRevision, 
       int index, ISettings settings)
       : base(smart, name, firmwareRevision, index, smartAttributes, settings) {}
-  }
+
+        private static float RawToGb(byte[] rawvalue, byte value, IReadOnlyArray<IParameter> parameters)
+        {
+            return RawToInt(rawvalue, value, parameters) / 32;
+        }
+    }
 }

--- a/Hardware/HDD/SSDSamsung.cs
+++ b/Hardware/HDD/SSDSamsung.cs
@@ -50,8 +50,9 @@ namespace OpenHardwareMonitor.Hardware.HDD {
       new SmartAttribute(0xC9, SmartNames.SupercapStatus),
       new SmartAttribute(0xCA, SmartNames.ExceptionModeStatus),
       new SmartAttribute(0xEB, SmartNames.PowerRecoveryCount),
-      new SmartAttribute(0xF1, SmartNames.TotalLBAWritten)
-    };
+      new SmartAttribute(0xF1, SmartNames.TotalLBAWritten, (byte[] r, byte v, IReadOnlyArray<IParameter> p)
+          => { return RawToInt(r, v, p) * 512 / 1024 / 1024 / 1024; },
+        SensorType.Data, 0, SmartNames.TotalLBAWritten)    };
 
     public SSDSamsung(ISmart smart, string name, string firmwareRevision,
       int index, ISettings settings)


### PR DESCRIPTION
Showing Samsung SSD's Total LBAs Written. 
Based on [official specification](http://www.samsung.com/global/business/semiconductor/minisite/SSD/downloads/document/07_Communicating_With_Your_SSD.pdf) from Samsung