### PR TITLE
Add support for Intel Airmont microarchitecture

### DIFF
--- a/Hardware/CPU/IntelCPU.cs
+++ b/Hardware/CPU/IntelCPU.cs
@@ -26,7 +26,8 @@ namespace OpenHardwareMonitor.Hardware.CPU {
       Haswell,
       Broadwell,
       Silvermont,
-      Skylake
+      Skylake,
+      Airmont
     }
 
     private readonly Sensor[] coreTemperatures;
@@ -171,6 +172,10 @@ namespace OpenHardwareMonitor.Hardware.CPU {
                 microarchitecture = Microarchitecture.Skylake;
                 tjMax = GetTjMaxFromMSR();
                 break;
+              case 0x4C:
+                microarchitecture = Microarchitecture.Airmont;
+                tjMax = GetTjMaxFromMSR();
+                break;
               default:
                 microarchitecture = Microarchitecture.Unknown;
                 tjMax = Floats(100);
@@ -217,7 +222,8 @@ namespace OpenHardwareMonitor.Hardware.CPU {
         case Microarchitecture.Haswell: 
         case Microarchitecture.Broadwell:
         case Microarchitecture.Silvermont:
-        case Microarchitecture.Skylake: {
+        case Microarchitecture.Skylake:
+        case Microarchitecture.Airmont: {
             uint eax, edx;
             if (Ring0.Rdmsr(MSR_PLATFORM_INFO, out eax, out edx)) {
               timeStampCounterMultiplier = (eax >> 8) & 0xff;
@@ -279,7 +285,8 @@ namespace OpenHardwareMonitor.Hardware.CPU {
           microarchitecture == Microarchitecture.Haswell ||
           microarchitecture == Microarchitecture.Broadwell || 
           microarchitecture == Microarchitecture.Skylake ||
-          microarchitecture == Microarchitecture.Silvermont) 
+          microarchitecture == Microarchitecture.Silvermont ||
+          microarchitecture == Microarchitecture.Airmont) 
       {
         powerSensors = new Sensor[energyStatusMSRs.Length];
         lastEnergyTime = new DateTime[energyStatusMSRs.Length];
@@ -289,6 +296,7 @@ namespace OpenHardwareMonitor.Hardware.CPU {
         if (Ring0.Rdmsr(MSR_RAPL_POWER_UNIT, out eax, out edx))
           switch (microarchitecture) {
             case Microarchitecture.Silvermont:
+            case Microarchitecture.Airmont:
               energyUnitMultiplier = 1.0e-6f * (1 << (int)((eax >> 8) & 0x1F));
               break;
             default:


### PR DESCRIPTION
I added support for the Airmont microarchitecture. Now CPU temps and power consumption are correctly displayed for Intel X5 Z8300 (verified on a Lattepanda featuring this exact CPU).
