### PR TITLE
Added customizable pen colors

### DIFF
--- a/GUI/HardwareNode.cs
+++ b/GUI/HardwareNode.cs
@@ -89,6 +89,8 @@ namespace OpenHardwareMonitor.GUI {
         ((SensorNode)node.Nodes[i]).Sensor.Index < sensor.Index)
         i++;
       SensorNode sensorNode = new SensorNode(sensor, settings, unitManager);
+      if (settings.Contains(sensor.Identifier + "/PenColor"))
+        sensorNode.penColor = settings.GetValue(sensor.Identifier + "/PenColor", Color.Black);
       sensorNode.PlotSelectionChanged += SensorPlotSelectionChanged;
       node.Nodes.Insert(i, sensorNode);
     }

--- a/GUI/MainForm.Designer.cs
+++ b/GUI/MainForm.Designer.cs
@@ -111,6 +111,7 @@ namespace OpenHardwareMonitor.GUI {
       this.log1hMenuItem = new System.Windows.Forms.MenuItem();
       this.log2hMenuItem = new System.Windows.Forms.MenuItem();
       this.log6hMenuItem = new System.Windows.Forms.MenuItem();
+      this.colorDialog = new System.Windows.Forms.ColorDialog();
       this.splitContainer.Panel1.SuspendLayout();
       this.splitContainer.SuspendLayout();
       this.SuspendLayout();
@@ -762,6 +763,7 @@ namespace OpenHardwareMonitor.GUI {
     private System.Windows.Forms.MenuItem log1hMenuItem;
     private System.Windows.Forms.MenuItem log2hMenuItem;
     private System.Windows.Forms.MenuItem log6hMenuItem;
+    private System.Windows.Forms.ColorDialog colorDialog;
   }
 }
 

--- a/GUI/MainForm.resx
+++ b/GUI/MainForm.resx
@@ -129,6 +129,9 @@
   <metadata name="timer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>293, 17</value>
   </metadata>
+  <metadata name="colorDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>483, 17</value>
+  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/GUI/SensorNode.cs
+++ b/GUI/SensorNode.cs
@@ -9,6 +9,7 @@
 */
 
 using System;
+using System.Drawing;
 using System.Collections.Generic;
 using OpenHardwareMonitor.Hardware;
 using OpenHardwareMonitor.Utilities;
@@ -20,7 +21,8 @@ namespace OpenHardwareMonitor.GUI {
     private PersistentSettings settings;
     private UnitManager unitManager;
     private string format;
-    private bool plot = false;       
+    private bool plot = false;
+    public Color? penColor = null;
 
     public string ValueToString(float? value) {
       if (value.HasValue) {

--- a/OpenHardwareMonitor.csproj
+++ b/OpenHardwareMonitor.csproj
@@ -66,6 +66,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration.Install" />
+    <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />
     <Reference Include="System.Windows.Forms" />


### PR DESCRIPTION
New node property, penColor, is null by default; this means that color
will be picked using the existing plotColorPalette method.
New node context menu item, Pen color, lets user choose the color to be
used when plotting this particular node.
This property is also saved/loaded from settings based on sensor
identifier.
