### PR TITLE
Expose SMARTAttributes for HDDs (Kind of)

### DIFF
--- a/Hardware/HDD/AbstractHarddrive.cs
+++ b/Hardware/HDD/AbstractHarddrive.cs
@@ -351,6 +351,20 @@ namespace OpenHardwareMonitor.Hardware.HDD {
       return r.ToString();
     }
 
+    public override object GetOther(AdditionalDataType type){
+      switch (type)
+      {
+        case AdditionalDataType.Driveinfos:
+          return driveInfos;
+        case AdditionalDataType.SmartAttributes:
+          return smartAttributes;
+        case AdditionalDataType.Firmware:
+          return firmwareRevision;
+        default:
+          return null;
+      }
+    }
+
     protected static float RawToInt(byte[] raw, byte value,
       IReadOnlyArray<IParameter> parameters) 
     {

--- a/Hardware/Hardware.cs
+++ b/Hardware/Hardware.cs
@@ -84,6 +84,10 @@ namespace OpenHardwareMonitor.Hardware {
       return null;
     }
 
+    public virtual object GetOther(AdditionalDataType type){
+      return null;
+    }
+
     public abstract void Update();
 
     public event HardwareEventHandler Closing;

--- a/Hardware/IHardware.cs
+++ b/Hardware/IHardware.cs
@@ -29,7 +29,8 @@ namespace OpenHardwareMonitor.Hardware
   public enum AdditionalDataType
   {
     Driveinfos,
-    SMART
+    SmartAttributes,
+    Firmware
   }
 
   public interface IHardware : IElement

--- a/Hardware/IHardware.cs
+++ b/Hardware/IHardware.cs
@@ -8,23 +8,32 @@
 	
 */
 
-namespace OpenHardwareMonitor.Hardware {
+namespace OpenHardwareMonitor.Hardware
+{
 
   public delegate void SensorEventHandler(ISensor sensor);
-  
-  public enum HardwareType {
+
+  public enum HardwareType
+  {
     Mainboard,
     SuperIO,
     CPU,
     RAM,
     GpuNvidia,
-    GpuAti,    
+    GpuAti,
     TBalancer,
     Heatmaster,
     HDD
   }
 
-  public interface IHardware : IElement {
+  public enum AdditionalDataType
+  {
+    Driveinfos,
+    SMART
+  }
+
+  public interface IHardware : IElement
+  {
 
     string Name { get; set; }
     Identifier Identifier { get; }
@@ -32,6 +41,8 @@ namespace OpenHardwareMonitor.Hardware {
     HardwareType HardwareType { get; }
 
     string GetReport();
+
+    object GetOther(AdditionalDataType type);
 
     void Update();
 

--- a/Hardware/Mainboard/Mainboard.cs
+++ b/Hardware/Mainboard/Mainboard.cs
@@ -111,6 +111,12 @@ namespace OpenHardwareMonitor.Hardware.Mainboard {
       return r.ToString();
     }
 
+    public object GetOther(AdditionalDataType type)
+    {
+      //Could be used here, too?
+      return null;
+    }
+
     public void Update() { }
 
     public void Close() {


### PR DESCRIPTION
Feel free to reject this, as it could probably be implemented better... But I needed a quick fix myself!

Addresses #456

The only way I had of working around this issue before was to parse the output of `GetReport()` and use that to query `WMI` and generate my own list of SMART attributes. It wasn't until I was debugging that I realised that OHM actually generates all this info itself, it's just not exposed!

Anyway, as I modified it to suit my own purposes, I figured I would share back upstream in case it was of any value.

Cheers!
