### PR TITLE
Add support for Intel Kaby Lake microarchitecture

### DIFF
--- a/Hardware/CPU/IntelCPU.cs
+++ b/Hardware/CPU/IntelCPU.cs
@@ -26,7 +26,8 @@ namespace OpenHardwareMonitor.Hardware.CPU {
       Haswell,
       Broadwell,
       Silvermont,
-      Skylake
+      Skylake,
+      KabyLake
     }
 
     private readonly Sensor[] coreTemperatures;
@@ -171,6 +172,10 @@ namespace OpenHardwareMonitor.Hardware.CPU {
                 microarchitecture = Microarchitecture.Skylake;
                 tjMax = GetTjMaxFromMSR();
                 break;
+              case 0x8E: // Intel Core i5, i7 7xxxx (14nm)
+                microarchitecture = Microarchitecture.KabyLake;
+                tjMax = GetTjMaxFromMSR();
+                break;
               default:
                 microarchitecture = Microarchitecture.Unknown;
                 tjMax = Floats(100);
@@ -217,7 +222,8 @@ namespace OpenHardwareMonitor.Hardware.CPU {
         case Microarchitecture.Haswell: 
         case Microarchitecture.Broadwell:
         case Microarchitecture.Silvermont:
-        case Microarchitecture.Skylake: {
+        case Microarchitecture.Skylake:
+        case Microarchitecture.KabyLake: {
             uint eax, edx;
             if (Ring0.Rdmsr(MSR_PLATFORM_INFO, out eax, out edx)) {
               timeStampCounterMultiplier = (eax >> 8) & 0xff;
@@ -279,7 +285,8 @@ namespace OpenHardwareMonitor.Hardware.CPU {
           microarchitecture == Microarchitecture.Haswell ||
           microarchitecture == Microarchitecture.Broadwell || 
           microarchitecture == Microarchitecture.Skylake ||
-          microarchitecture == Microarchitecture.Silvermont) 
+          microarchitecture == Microarchitecture.Silvermont ||
+          microarchitecture == Microarchitecture.KabyLake) 
       {
         powerSensors = new Sensor[energyStatusMSRs.Length];
         lastEnergyTime = new DateTime[energyStatusMSRs.Length];


### PR DESCRIPTION
I added support for Intel Kaby Lake CPUs (temperatures, clocks, power consumption).
Tested on a HP 15-ay114ng notebook with Intel Core i5-7200U CPU.
