### PR TITLE
Added support for Gigabyte AX370 Gaming K7 (Added Partial-Ryzen Support Too)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 *.suo
 /Bin
 /Obj
+/.vs/openhardwaremonitor/v15/Browse.VC.db
+/.vs/ProjectSettings.json
+/.vs/slnx.sqlite
+/.vs/VSWorkspaceState.json

--- a/Hardware/CPU/AMD10CPU.cs
+++ b/Hardware/CPU/AMD10CPU.cs
@@ -40,10 +40,11 @@ namespace OpenHardwareMonitor.Hardware.CPU {
     private const ushort FAMILY_15H_MODEL_30_MISC_CONTROL_DEVICE_ID = 0x141D;
     private const ushort FAMILY_16H_MODEL_00_MISC_CONTROL_DEVICE_ID = 0x1533;
     private const ushort FAMILY_16H_MODEL_30_MISC_CONTROL_DEVICE_ID = 0x1583;
+    private const ushort FAMILY_17H_MISCELLANEOUS_CONTROL_DEVICE_ID = 0x1577; // TODO: This most likely isn't right.
 
     private const uint REPORTED_TEMPERATURE_CONTROL_REGISTER = 0xA4;
     private const uint CLOCK_POWER_TIMING_CONTROL_0_REGISTER = 0xD4;
-
+        
     private readonly uint miscellaneousControlAddress;
     private readonly ushort miscellaneousControlDeviceId;
 
@@ -89,7 +90,12 @@ namespace OpenHardwareMonitor.Hardware.CPU {
               FAMILY_16H_MODEL_30_MISC_CONTROL_DEVICE_ID; break;
             default: miscellaneousControlDeviceId = 0; break;
           } break;
-        default: miscellaneousControlDeviceId = 0; break;
+        case 0x17:
+        {
+            miscellaneousControlDeviceId = FAMILY_17H_MISCELLANEOUS_CONTROL_DEVICE_ID;
+            break;
+        }
+                default: miscellaneousControlDeviceId = 0; break;
       }
 
       // get the pci address for the Miscellaneous Control registers 
@@ -327,6 +333,10 @@ namespace OpenHardwareMonitor.Hardware.CPU {
             DeactivateSensor(coreTemperature);
           }
         }
+        else
+                {
+                    Console.WriteLine("????");
+                }
       } else {
         string s = ReadFirstLine(temperatureStream);
         try {

--- a/Hardware/CPU/AMD10CPU.cs
+++ b/Hardware/CPU/AMD10CPU.cs
@@ -90,12 +90,9 @@ namespace OpenHardwareMonitor.Hardware.CPU {
               FAMILY_16H_MODEL_30_MISC_CONTROL_DEVICE_ID; break;
             default: miscellaneousControlDeviceId = 0; break;
           } break;
-        case 0x17:
-        {
-            miscellaneousControlDeviceId = FAMILY_17H_MISCELLANEOUS_CONTROL_DEVICE_ID;
-            break;
-        }
-                default: miscellaneousControlDeviceId = 0; break;
+        case 0x17: miscellaneousControlDeviceId = 
+            FAMILY_17H_MISCELLANEOUS_CONTROL_DEVICE_ID; break;
+        default: miscellaneousControlDeviceId = 0; break;
       }
 
       // get the pci address for the Miscellaneous Control registers 
@@ -333,10 +330,6 @@ namespace OpenHardwareMonitor.Hardware.CPU {
             DeactivateSensor(coreTemperature);
           }
         }
-        else
-                {
-                    Console.WriteLine("????");
-                }
       } else {
         string s = ReadFirstLine(temperatureStream);
         try {

--- a/Hardware/CPU/CPUGroup.cs
+++ b/Hardware/CPU/CPUGroup.cs
@@ -102,6 +102,7 @@ namespace OpenHardwareMonitor.Hardware.CPU {
               case 0x14:
               case 0x15:
               case 0x16:
+              case 0x17:
                 hardware.Add(new AMD10CPU(index, coreThreads, settings));
                 break;
               default:

--- a/Hardware/LPC/Chip.cs
+++ b/Hardware/LPC/Chip.cs
@@ -27,6 +27,7 @@ namespace OpenHardwareMonitor.Hardware.LPC {
 
     IT8620E = 0x8620,
     IT8628E = 0x8628,
+    IT8686E = 0x8686,
     IT8705F = 0x8705,
     IT8712F = 0x8712,
     IT8716F = 0x8716,
@@ -74,6 +75,7 @@ namespace OpenHardwareMonitor.Hardware.LPC {
 
         case Chip.IT8620E: return "ITE IT8620E";
         case Chip.IT8628E: return "ITE IT8628E";
+        case Chip.IT8686E: return "ITE IT8686E";
         case Chip.IT8705F: return "ITE IT8705F";
         case Chip.IT8712F: return "ITE IT8712F";
         case Chip.IT8716F: return "ITE IT8716F";

--- a/Hardware/LPC/IT87XX.cs
+++ b/Hardware/LPC/IT87XX.cs
@@ -138,15 +138,26 @@ namespace OpenHardwareMonitor.Hardware.LPC {
       if (!valid)
         return;
 
-      voltages = new float?[9];
-      temperatures = new float?[3];
-      fans = new float?[chip == Chip.IT8705F ? 3 : 5];
-      controls = new float?[3];
+      // IT8686E has more sensors
+      if(chip == Chip.IT8686E)
+      {
+        voltages = new float?[10];
+        temperatures = new float?[5];
+        fans = new float?[5];
+        controls = new float?[3];
+      }
+      else
+      {
+        voltages = new float?[9];
+        temperatures = new float?[5];
+        fans = new float?[chip == Chip.IT8705F ? 3 : 5];
+        controls = new float?[3];
+      }
 
-      // IT8620E, IT8628E, IT8721F, IT8728F and IT8772E use a 12mV resultion 
+      // IT8620E, IT8628E, IT8721F, IT8728F, IT8772E and IT8686E use a 12mV resultion 
       // ADC, all others 16mV
       if (chip == Chip.IT8620E || chip == Chip.IT8628E || chip == Chip.IT8721F 
-        || chip == Chip.IT8728F || chip == Chip.IT8771E || chip == Chip.IT8772E) 
+        || chip == Chip.IT8728F || chip == Chip.IT8771E || chip == Chip.IT8772E || chip == Chip.IT8686E) 
       {
         voltageGain = 0.012f;
       } else {

--- a/Hardware/LPC/IT87XX.cs
+++ b/Hardware/LPC/IT87XX.cs
@@ -149,7 +149,7 @@ namespace OpenHardwareMonitor.Hardware.LPC {
       else
       {
         voltages = new float?[9];
-        temperatures = new float?[5];
+        temperatures = new float?[3];
         fans = new float?[chip == Chip.IT8705F ? 3 : 5];
         controls = new float?[3];
       }

--- a/Hardware/LPC/LPCIO.cs
+++ b/Hardware/LPC/LPCIO.cs
@@ -333,6 +333,7 @@ namespace OpenHardwareMonitor.Hardware.LPC {
       switch (chipID) {
         case 0x8620: chip = Chip.IT8620E; break;
         case 0x8628: chip = Chip.IT8628E; break;
+        case 0x8686: chip = Chip.IT8686E; break; 
         case 0x8705: chip = Chip.IT8705F; break;
         case 0x8712: chip = Chip.IT8712F; break;
         case 0x8716: chip = Chip.IT8716F; break;

--- a/Hardware/Mainboard/Identification.cs
+++ b/Hardware/Mainboard/Identification.cs
@@ -190,6 +190,8 @@ namespace OpenHardwareMonitor.Hardware.Mainboard {
           return Model.Z68X_UD7_B3;
         case "FH67":
           return Model.FH67;
+        case "AX370-Gaming K7":
+          return Model.AX370_K7;
         case "Base Board Product Name":
         case "To be filled by O.E.M.":
           return Model.Unknown;

--- a/Hardware/Mainboard/Model.cs
+++ b/Hardware/Mainboard/Model.cs
@@ -79,6 +79,7 @@ namespace OpenHardwareMonitor.Hardware.Mainboard {
     Z68AP_D3,
     Z68X_UD3H_B3,
     Z68X_UD7_B3,
+    AX370_K7,
 
     // Shuttle
     FH67,

--- a/Hardware/Mainboard/SuperIOHardware.cs
+++ b/Hardware/Mainboard/SuperIOHardware.cs
@@ -182,6 +182,7 @@ namespace OpenHardwareMonitor.Hardware.Mainboard {
         case Chip.IT8718F:
         case Chip.IT8720F:
         case Chip.IT8726F:
+        case Chip.IT8686E:
           GetITEConfigurationsA(superIO, manufacturer, model, v, t, f, c,
             ref readFan, ref postUpdate, ref mutex);
           break;
@@ -601,6 +602,26 @@ namespace OpenHardwareMonitor.Hardware.Mainboard {
               f.Add(new Fan("System Fan #2", 1));
               f.Add(new Fan("Power Fan", 2));
               f.Add(new Fan("System Fan #1", 3));
+              break;
+            case Model.AX370_K7: // IT8686E
+              // Note: v3.3, v12, v5, and AVCC3 might be slightly off.
+              v.Add(new Voltage("CPU VCore", 0));
+              v.Add(new Voltage("+3.3V", 1, 0.65f, 1));
+              v.Add(new Voltage("+12V", 2, 5, 1));
+              v.Add(new Voltage("+5V", 3, 1.5f, 1));
+              v.Add(new Voltage("VSOC", 4));
+              v.Add(new Voltage("VDDP", 5));
+              v.Add(new Voltage("VDRAM", 6));
+              v.Add(new Voltage("3VSB", 7, 10, 10));
+              v.Add(new Voltage("VBAT", 8, 10, 10));
+              v.Add(new Voltage("AVCC3", 9, 7.53f, 1));
+              t.Add(new Temperature("System", 0));
+              t.Add(new Temperature("Chipset", 1));
+              t.Add(new Temperature("CPU", 2));
+              t.Add(new Temperature("PCIEX16", 3));
+              t.Add(new Temperature("VRM MOS", 4));
+              for (int i = 0; i < superIO.Fans.Length; i++)
+                f.Add(new Fan("Fan #" + (i + 1), i));
               break;
             default:
               v.Add(new Voltage("CPU VCore", 0));


### PR DESCRIPTION
![AX370](http://i.imgur.com/qTf4Y6W.png)

I have not figured out how to get Ryzen's Temperature / Vcore sensors yet as AMD hasn't released their guide on how to do this. Also, some of the scalars for the voltages (e.g. +12v) I reverse calculated based on HWiNFO's data.