### PR TITLE
Added support for NVMe

### DIFF
--- a/Hardware/HDD/AbstractHarddrive.cs
+++ b/Hardware/HDD/AbstractHarddrive.cs
@@ -18,10 +18,8 @@ using System.Text;
 using OpenHardwareMonitor.Collections;
 
 namespace OpenHardwareMonitor.Hardware.HDD {
-  internal abstract class AbstractHarddrive : Hardware {
-
-    private const int UPDATE_DIVIDER = 30; // update only every 30s
-
+  internal abstract class ATAStorage : AbstractStorage {
+    
     // array of all harddrive types, matching type is searched in this order
     private static Type[] hddTypes = {       
       typeof(SSDPlextor),
@@ -33,81 +31,50 @@ namespace OpenHardwareMonitor.Hardware.HDD {
       typeof(GenericHarddisk)
     };
 
-    private string firmwareRevision;
     private readonly ISmart smart;
-
-    private readonly IntPtr handle;
-    private readonly int index;
-    private int count;
 
     private IList<SmartAttribute> smartAttributes;
     private IDictionary<SmartAttribute, Sensor> sensors;
 
-    private DriveInfo[] driveInfos;
-    private Sensor usageSensor;
-
-    protected AbstractHarddrive(ISmart smart, string name, 
-      string firmwareRevision, int index, 
+    protected ATAStorage(ISmart smart, string name, 
+      string firmwareRevision, string id, int index, 
       IEnumerable<SmartAttribute> smartAttributes, ISettings settings) 
-      : base(name, new Identifier("hdd",
-        index.ToString(CultureInfo.InvariantCulture)), settings)
+      : base(name, firmwareRevision, id, index, settings)
     {
-      this.firmwareRevision = firmwareRevision;
       this.smart = smart;
-      handle = smart.OpenDrive(index);
-
-      if (handle != smart.InvalidHandle)
-        smart.EnableSmart(handle, index);
-
-      this.index = index;
-      this.count = 0;
+      
+      if (smart.IsValid)
+        smart.EnableSmart();
 
       this.smartAttributes = new List<SmartAttribute>(smartAttributes);
-
-      string[] logicalDrives = smart.GetLogicalDrives(index);
-      List<DriveInfo> driveInfoList = new List<DriveInfo>(logicalDrives.Length);
-      foreach (string logicalDrive in logicalDrives) {
-        try {
-          DriveInfo di = new DriveInfo(logicalDrive);
-          if (di.TotalSize > 0)
-            driveInfoList.Add(new DriveInfo(logicalDrive));
-        } catch (ArgumentException) {
-        } catch (IOException) {
-        } catch (UnauthorizedAccessException) {
-        }
-      }
-      driveInfos = driveInfoList.ToArray();
-
+    
       CreateSensors();
     }
 
-    public static AbstractHarddrive CreateInstance(ISmart smart, 
-      int driveIndex, ISettings settings) 
-    {
-      IntPtr deviceHandle = smart.OpenDrive(driveIndex);
+    public static AbstractStorage CreateInstance(StorageInfo info, ISettings settings) {
+      ISmart smart = new WindowsSmart(info.Index);
 
       string name = null;
       string firmwareRevision = null;
       DriveAttributeValue[] values = { };
 
-      if (deviceHandle != smart.InvalidHandle) {
-        bool nameValid = smart.ReadNameAndFirmwareRevision(deviceHandle,
-        driveIndex, out name, out firmwareRevision);
-        bool smartEnabled = smart.EnableSmart(deviceHandle, driveIndex);
+      if (smart.IsValid) {
+        bool nameValid = smart.ReadNameAndFirmwareRevision(out name, out firmwareRevision);
+        bool smartEnabled = smart.EnableSmart();
 
         if (smartEnabled)
-          values = smart.ReadSmartData(deviceHandle, driveIndex);
-
-        smart.CloseHandle(deviceHandle);
+          values = smart.ReadSmartData();
 
         if (!nameValid) {
           name = null;
           firmwareRevision = null;
         }
       } else {
-        string[] logicalDrives = smart.GetLogicalDrives(driveIndex);
-        if (logicalDrives == null || logicalDrives.Length == 0)
+        string[] logicalDrives = WindowsStorage.GetLogicalDrives(info.Index);
+        if (logicalDrives == null || logicalDrives.Length == 0) {
+          smart.Close();
           return null;
+        }
 
         bool hasNonZeroSizeDrive = false;
         foreach (string logicalDrive in logicalDrives) {
@@ -123,15 +90,17 @@ namespace OpenHardwareMonitor.Hardware.HDD {
           }
         }
 
-        if (!hasNonZeroSizeDrive)
+        if (!hasNonZeroSizeDrive) {
+          smart.Close();
           return null;
+        }
       }
 
       if (string.IsNullOrEmpty(name))
-        name = "Generic Hard Disk";
+        name = string.IsNullOrEmpty(info.Name) ? "Generic Hard Disk" : info.Name;
 
       if (string.IsNullOrEmpty(firmwareRevision))
-        firmwareRevision = "Unknown";
+        firmwareRevision = string.IsNullOrEmpty(info.Revision) ? "Unknown" : info.Revision;
 
       foreach (Type type in hddTypes) {
         // get the array of name prefixes for the current type
@@ -166,22 +135,23 @@ namespace OpenHardwareMonitor.Hardware.HDD {
         foreach (NamePrefixAttribute prefix in namePrefixes) {
           if (name.StartsWith(prefix.Prefix, StringComparison.InvariantCulture)) 
             return Activator.CreateInstance(type, smart, name, firmwareRevision,
-              driveIndex, settings) as AbstractHarddrive;
+              info.Index, settings) as ATAStorage;
         }
       }
 
       // no matching type has been found
+      smart.Close();
       return null;
     }
 
-    private void CreateSensors() {
+    protected override sealed void CreateSensors() {
       sensors = new Dictionary<SmartAttribute, Sensor>();
 
-      if (handle != smart.InvalidHandle) {
+      if (smart.IsValid) {
         IList<Pair<SensorType, int>> sensorTypeAndChannels =
           new List<Pair<SensorType, int>>();
 
-        DriveAttributeValue[] values = smart.ReadSmartData(handle, index);
+        DriveAttributeValue[] values = smart.ReadSmartData();
 
         foreach (SmartAttribute attribute in smartAttributes) {
           if (!attribute.SensorType.HasValue)
@@ -213,75 +183,34 @@ namespace OpenHardwareMonitor.Hardware.HDD {
         }
       }
 
-      if (driveInfos.Length > 0) {
-        usageSensor = 
-          new Sensor("Used Space", 0, SensorType.Load, this, settings);
-        ActivateSensor(usageSensor);
-      }
-    }
-
-    public override HardwareType HardwareType {
-      get { return HardwareType.HDD; }
+      base.CreateSensors();
     }
 
     public virtual void UpdateAdditionalSensors(DriveAttributeValue[] values) {}
 
-    public override void Update() {
-      if (count == 0) {
-        if (handle != smart.InvalidHandle) {
-          DriveAttributeValue[] values = smart.ReadSmartData(handle, index);
+    protected override void UpdateSensors() {
+      if (smart.IsValid) {
+        DriveAttributeValue[] values = smart.ReadSmartData();
 
-          foreach (KeyValuePair<SmartAttribute, Sensor> keyValuePair in sensors) 
-          {
-            SmartAttribute attribute = keyValuePair.Key;
-            foreach (DriveAttributeValue value in values) {
-              if (value.Identifier == attribute.Identifier) {
-                Sensor sensor = keyValuePair.Value;
-                sensor.Value = attribute.ConvertValue(value, sensor.Parameters);
-              }
+        foreach (KeyValuePair<SmartAttribute, Sensor> keyValuePair in sensors) 
+        {
+          SmartAttribute attribute = keyValuePair.Key;
+          foreach (DriveAttributeValue value in values) {
+            if (value.Identifier == attribute.Identifier) {
+              Sensor sensor = keyValuePair.Value;
+              sensor.Value = attribute.ConvertValue(value, sensor.Parameters);
             }
           }
-
-          UpdateAdditionalSensors(values);
         }
 
-        if (usageSensor != null) {
-          long totalSize = 0;
-          long totalFreeSpace = 0;
-
-          for (int i = 0; i < driveInfos.Length; i++) {
-            if (!driveInfos[i].IsReady)
-              continue;
-            try {
-              totalSize += driveInfos[i].TotalSize;
-              totalFreeSpace += driveInfos[i].TotalFreeSpace;
-            } catch (IOException) { } catch (UnauthorizedAccessException) { }
-          }
-          if (totalSize > 0) {
-            usageSensor.Value = 100.0f - (100.0f * totalFreeSpace) / totalSize;
-          } else {
-            usageSensor.Value = null;
-          }
-        }
+        UpdateAdditionalSensors(values);
       }
-
-      count++; 
-      count %= UPDATE_DIVIDER; 
     }
 
-    public override string GetReport() {
-      StringBuilder r = new StringBuilder();
-
-      r.AppendLine(this.GetType().Name);
-      r.AppendLine();
-      r.AppendLine("Drive name: " + name);
-      r.AppendLine("Firmware version: " + firmwareRevision);
-      r.AppendLine();
-
-      if (handle != smart.InvalidHandle) {
-        DriveAttributeValue[] values = smart.ReadSmartData(handle, index);
-        DriveThresholdValue[] thresholds =
-          smart.ReadSmartThresholds(handle, index);
+    protected override void GetReport(StringBuilder r) {
+      if (smart.IsValid) {
+        DriveAttributeValue[] values = smart.ReadSmartData();
+        DriveThresholdValue[] thresholds = smart.ReadSmartThresholds();
 
         if (values.Length > 0) {
           r.AppendFormat(CultureInfo.InvariantCulture,
@@ -335,20 +264,6 @@ namespace OpenHardwareMonitor.Hardware.HDD {
           r.AppendLine();
         }
       }
-
-      foreach (DriveInfo di in driveInfos) {
-        if (!di.IsReady)
-          continue;
-        try {
-          r.AppendLine("Logical drive name: " + di.Name);
-          r.AppendLine("Format: " + di.DriveFormat);
-          r.AppendLine("Total size: " + di.TotalSize);
-          r.AppendLine("Total free space: " + di.TotalFreeSpace);
-          r.AppendLine();
-        } catch (IOException) { } catch (UnauthorizedAccessException) { }
-      }
-
-      return r.ToString();
     }
 
     protected static float RawToInt(byte[] raw, byte value,
@@ -358,15 +273,9 @@ namespace OpenHardwareMonitor.Hardware.HDD {
     }
 
     public override void Close() {
-      if (handle != smart.InvalidHandle)
-        smart.CloseHandle(handle);
-
+      smart.Close();
+      
       base.Close();
-    }
-
-    public override void Traverse(IVisitor visitor) {
-      foreach (ISensor sensor in Sensors)
-        sensor.Accept(visitor);
     }
   }
 }

--- a/Hardware/HDD/AbstractStorage.cs
+++ b/Hardware/HDD/AbstractStorage.cs
@@ -1,0 +1,143 @@
+﻿/*
+ 
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ 
+  Copyright (C) 2009-2015 Michael Möller <mmoeller@openhardwaremonitor.org>
+	Copyright (C) 2010 Paul Werelds
+  Copyright (C) 2011 Roland Reinl <roland-reinl@gmx.de>
+	
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+
+namespace OpenHardwareMonitor.Hardware.HDD {
+  internal abstract class AbstractStorage : Hardware {
+
+    private const int UPDATE_DIVIDER = 30; // update only every 30s
+
+    protected string firmwareRevision;
+    
+    protected readonly int index;
+    private int count;
+    
+    private DriveInfo[] driveInfos;
+    private Sensor usageSensor;
+
+    protected AbstractStorage(string name, string firmwareRevision, 
+      string id, int index, ISettings settings) 
+      : base(name, new Identifier(id,
+        index.ToString(CultureInfo.InvariantCulture)), settings)
+    {
+      this.firmwareRevision = firmwareRevision;
+      
+      this.index = index;
+      this.count = 0;
+
+      string[] logicalDrives = WindowsStorage.GetLogicalDrives(index);
+      List<DriveInfo> driveInfoList = new List<DriveInfo>(logicalDrives.Length);
+      foreach (string logicalDrive in logicalDrives) {
+        try {
+          DriveInfo di = new DriveInfo(logicalDrive);
+          if (di.TotalSize > 0)
+            driveInfoList.Add(new DriveInfo(logicalDrive));
+        } catch (ArgumentException) {
+        } catch (IOException) {
+        } catch (UnauthorizedAccessException) {
+        }
+      }
+      driveInfos = driveInfoList.ToArray();
+    }
+
+    public static AbstractStorage CreateInstance(int driveNumber, ISettings settings) {
+      StorageInfo info = WindowsStorage.GetStorageInfo(driveNumber);
+      if (info == null || info.Removable)
+        return null;
+      if (info.BusType == StorageBusType.BusTypeAta || info.BusType == StorageBusType.BusTypeSata)
+        return ATAStorage.CreateInstance(info, settings);
+      if (info.BusType == StorageBusType.BusTypeNvme)
+        return NVMeGeneric.CreateInstance(info, settings);
+      return StorageGeneric.CreateInstance(info, settings);
+    }
+    
+    protected virtual void CreateSensors() {
+      if (driveInfos.Length > 0) {
+        usageSensor = 
+          new Sensor("Used Space", 0, SensorType.Load, this, settings);
+        ActivateSensor(usageSensor);
+      }
+    }
+
+    public override HardwareType HardwareType {
+      get { return HardwareType.HDD; }
+    }
+
+    protected abstract void UpdateSensors();
+    
+    public override void Update() {
+      if (count == 0) {
+        UpdateSensors();
+
+        if (usageSensor != null) {
+          long totalSize = 0;
+          long totalFreeSpace = 0;
+
+          for (int i = 0; i < driveInfos.Length; i++) {
+            if (!driveInfos[i].IsReady)
+              continue;
+            try {
+              totalSize += driveInfos[i].TotalSize;
+              totalFreeSpace += driveInfos[i].TotalFreeSpace;
+            } catch (IOException) { } catch (UnauthorizedAccessException) { }
+          }
+          if (totalSize > 0) {
+            usageSensor.Value = 100.0f - (100.0f * totalFreeSpace) / totalSize;
+          } else {
+            usageSensor.Value = null;
+          }
+        }
+      }
+
+      count++; 
+      count %= UPDATE_DIVIDER; 
+    }
+
+    protected abstract void GetReport(StringBuilder r);
+    
+    public override string GetReport() {
+      StringBuilder r = new StringBuilder();
+
+      r.AppendLine(this.GetType().Name);
+      r.AppendLine();
+      r.AppendLine("Drive name: " + name);
+      r.AppendLine("Firmware version: " + firmwareRevision);
+      r.AppendLine();
+
+      GetReport(r);
+
+      foreach (DriveInfo di in driveInfos) {
+        if (!di.IsReady)
+          continue;
+        try {
+          r.AppendLine("Logical drive name: " + di.Name);
+          r.AppendLine("Format: " + di.DriveFormat);
+          r.AppendLine("Total size: " + di.TotalSize);
+          r.AppendLine("Total free space: " + di.TotalFreeSpace);
+          r.AppendLine();
+        } catch (IOException) { } catch (UnauthorizedAccessException) { }
+      }
+
+      return r.ToString();
+    }
+
+    public override void Traverse(IVisitor visitor) {
+      foreach (ISensor sensor in Sensors)
+        sensor.Accept(visitor);
+    }
+  }
+}

--- a/Hardware/HDD/DebugSmart.cs
+++ b/Hardware/HDD/DebugSmart.cs
@@ -17,7 +17,8 @@ namespace OpenHardwareMonitor.Hardware.HDD {
 #if DEBUG
 
   internal class DebugSmart : ISmart {
-
+    private int driveNumber;
+  
     private Drive[] drives = {
       new Drive("KINGSTON SNV425S264GB", null, 16,
         @" 01 000000000000 100 100      
@@ -331,48 +332,44 @@ namespace OpenHardwareMonitor.Hardware.HDD {
             EB 690000000000 99  99  0  
             F1 A56AA1F60200 99  99  0")};
 
-    public IntPtr OpenDrive(int driveNumber) {
-      if (driveNumber < drives.Length)
-        return (IntPtr)driveNumber;
-      else
-        return InvalidHandle;
+    public DebugSmart(int driveNumber) {
+      this.driveNumber = driveNumber;
     }
-
-    public bool EnableSmart(IntPtr handle, int driveNumber) {
-      if (handle != (IntPtr)driveNumber)
-        throw new ArgumentOutOfRangeException();
-
+    
+    public bool IsValid {
+      get { return true; }
+    }
+    
+    public void Close() {      
+      Dispose(true);
+      GC.SuppressFinalize(this);
+    }
+    
+    public bool EnableSmart() {
+      if (driveNumber < 0)
+        throw new ObjectDisposedException("DebugSmart");
       return true;
     }
-
-    public DriveAttributeValue[] ReadSmartData(IntPtr handle, int driveNumber) {
-      if (handle != (IntPtr)driveNumber)
-        throw new ArgumentOutOfRangeException();
-
+  
+    public DriveAttributeValue[] ReadSmartData() {
+      if (driveNumber < 0)
+        throw new ObjectDisposedException("DebugSmart");
       return drives[driveNumber].DriveAttributeValues;
     }
 
-    public DriveThresholdValue[] ReadSmartThresholds(IntPtr handle, 
-      int driveNumber) 
-    {
-      if (handle != (IntPtr)driveNumber)
-        throw new ArgumentOutOfRangeException();
-
+    public DriveThresholdValue[] ReadSmartThresholds() {
+      if (driveNumber < 0)
+        throw new ObjectDisposedException("DebugSmart");
       return drives[driveNumber].DriveThresholdValues;
     }
 
-    public bool ReadNameAndFirmwareRevision(IntPtr handle, int driveNumber, 
-      out string name, out string firmwareRevision) {
-      if (handle != (IntPtr)driveNumber)
-        throw new ArgumentOutOfRangeException();
-
+    public bool ReadNameAndFirmwareRevision(out string name, out string firmwareRevision) {
+      if (driveNumber < 0)
+        throw new ObjectDisposedException("DebugSmart");
       name = drives[driveNumber].Name;
       firmwareRevision = drives[driveNumber].FirmwareVersion;
       return true;
     }
-
-    public void CloseHandle(IntPtr handle) { }
-
 
     private class Drive {
 
@@ -427,10 +424,13 @@ namespace OpenHardwareMonitor.Hardware.HDD {
       public string FirmwareVersion { get; private set; }
     }
 
-    public IntPtr InvalidHandle { get { return (IntPtr)(-1); } }
-
-    public string[] GetLogicalDrives(int driveIndex) {
-      return new string[0];
+    public void Dispose() {
+      Close();
+    }
+    
+    protected void Dispose(bool disposing) {
+      if (disposing)
+        driveNumber = -1;
     }
   }
 

--- a/Hardware/HDD/HDDGeneric.cs
+++ b/Hardware/HDD/HDDGeneric.cs
@@ -18,7 +18,7 @@ using OpenHardwareMonitor.Collections;
 namespace OpenHardwareMonitor.Hardware.HDD {
 
   [NamePrefix("")]
-  internal class GenericHarddisk : AbstractHarddrive {
+  internal class GenericHarddisk : ATAStorage {
 
     private static readonly List<SmartAttribute> smartAttributes =
       new List<SmartAttribute> {
@@ -107,6 +107,6 @@ namespace OpenHardwareMonitor.Hardware.HDD {
 
     public GenericHarddisk(ISmart smart, string name, string firmwareRevision, 
       int index, ISettings settings)
-      : base(smart, name, firmwareRevision, index, smartAttributes, settings) {}
+      : base(smart, name, firmwareRevision, "hdd", index, smartAttributes, settings) {}
   }
 }

--- a/Hardware/HDD/HarddriveGroup.cs
+++ b/Hardware/HDD/HarddriveGroup.cs
@@ -20,18 +20,16 @@ namespace OpenHardwareMonitor.Hardware.HDD {
 
     private const int MAX_DRIVES = 32;
 
-    private readonly List<AbstractHarddrive> hardware = 
-      new List<AbstractHarddrive>();
+    private readonly List<AbstractStorage> hardware = 
+      new List<AbstractStorage>();
 
     public HarddriveGroup(ISettings settings) {
       int p = (int)Environment.OSVersion.Platform;
       if (p == 4 || p == 128) return;
 
-      ISmart smart = new WindowsSmart();
-
       for (int drive = 0; drive < MAX_DRIVES; drive++) {
-        AbstractHarddrive instance =
-          AbstractHarddrive.CreateInstance(smart, drive, settings);
+        AbstractStorage instance =
+          AbstractStorage.CreateInstance(drive, settings);
         if (instance != null) {
           this.hardware.Add(instance);
         }
@@ -49,8 +47,8 @@ namespace OpenHardwareMonitor.Hardware.HDD {
     }
 
     public void Close() {
-      foreach (AbstractHarddrive hdd in hardware) 
-        hdd.Close();
+      foreach (AbstractStorage storage in hardware) 
+        storage.Close();
     }
   }
 }

--- a/Hardware/HDD/ISmart.cs
+++ b/Hardware/HDD/ISmart.cs
@@ -9,28 +9,20 @@
 */
 
 using System;
-using System.Collections.Generic;
-
 
 namespace OpenHardwareMonitor.Hardware.HDD {
 
-  internal interface ISmart {
+  internal interface ISmart : IDisposable {
+    bool IsValid { get; }
+    
+    void Close();
 
-    IntPtr OpenDrive(int driveNumber);
+    bool EnableSmart();
+      
+    DriveAttributeValue[] ReadSmartData();
 
-    bool EnableSmart(IntPtr handle, int driveNumber);
+    DriveThresholdValue[] ReadSmartThresholds();
 
-    DriveAttributeValue[] ReadSmartData(IntPtr handle, int driveNumber);
-
-    DriveThresholdValue[] ReadSmartThresholds(IntPtr handle, int driveNumber);
-
-    bool ReadNameAndFirmwareRevision(IntPtr handle, int driveNumber,
-      out string name, out string firmwareRevision); 
-
-    void CloseHandle(IntPtr handle);
-
-    IntPtr InvalidHandle { get; }
-
-    string[] GetLogicalDrives(int driveIndex);
+    bool ReadNameAndFirmwareRevision(out string name, out string firmwareRevision); 
   }
 }

--- a/Hardware/HDD/NVMeGeneric.cs
+++ b/Hardware/HDD/NVMeGeneric.cs
@@ -19,11 +19,11 @@ namespace OpenHardwareMonitor.Hardware.HDD {
     private class NVMeSensor : Sensor {
       private readonly GetSensorValue getValue;
       
-      public NVMeSensor(string name, int index, bool defaultHidden, 
+      public NVMeSensor(string name, int index, bool defaultHidden,
         SensorType sensorType, Hardware hardware, ISettings settings,
         GetSensorValue getValue)
         : base(name, index, defaultHidden, sensorType, hardware, null, settings)
-      {        
+      {
         this.getValue = getValue;
       }
 
@@ -47,7 +47,7 @@ namespace OpenHardwareMonitor.Hardware.HDD {
       CreateSensors();
     }
      
-    // \\.\ScsiY: is different from \\.\PhysicalDriveX, user serial number for mapping     
+    // \\.\ScsiY: is different from \\.\PhysicalDriveX, user serial number for mapping
     private static NVMeInfo GetDeviceInfo(string serial) {
       if (serialToInfo == null) {
         serialToInfo = new Dictionary<string, NVMeInfo>();
@@ -71,7 +71,7 @@ namespace OpenHardwareMonitor.Hardware.HDD {
         return null;
       return new NVMeGeneric(nvmeInfo, storageInfo.Index, settings);
     }
-            
+    
     protected override void CreateSensors() {
       AddSensor("Temperature", 0, false, SensorType.Temperature, (health) => health.Temperature);
       AddSensor("Available Spare", 0, false, SensorType.Level, (health) => health.AvailableSpare);
@@ -88,7 +88,7 @@ namespace OpenHardwareMonitor.Hardware.HDD {
       base.CreateSensors();
     }
     
-    private void AddSensor(string name, int index, bool defaultHidden, 
+    private void AddSensor(string name, int index, bool defaultHidden,
       SensorType sensorType, GetSensorValue getValue)
     {
       NVMeSensor sensor = new NVMeSensor(name, index, defaultHidden, sensorType, this, settings, getValue);
@@ -141,13 +141,14 @@ namespace OpenHardwareMonitor.Hardware.HDD {
         if ((health.CriticalWarning & NVMeCriticalWarning.VolatileMemoryBackupDeviceFailed) != 0)
           r.AppendLine("Critical Warning: the volatile memory backup device has failed.");
       }
-      r.AppendLine("Temperature: " + health.Temperature +" Celsius");
-      r.AppendLine("Available Spare: " + health.AvailableSpare +"%");
-      r.AppendLine("Available Spare Threshold: " + health.AvailableSpareThreshold +"%");
+      r.AppendLine("Temperature: " + health.Temperature + " Celsius");
+      r.AppendLine("Available Spare: " + health.AvailableSpare + "%");
+      r.AppendLine("Available Spare Threshold: " + health.AvailableSpareThreshold + "%");
+      r.AppendLine("Percentage Used: " + health.PercentageUsed + "%");
       r.AppendLine("Data Units Read: " + health.DataUnitRead);
       r.AppendLine("Data Units Written: " + health.DataUnitWritten);
       r.AppendLine("Host Read Commands: " + health.HostReadCommands);
-      r.AppendLine("Data Write Commands: " + health.HostWrittenCommands);
+      r.AppendLine("Host Write Commands: " + health.HostWriteCommands);
       r.AppendLine("Controller Busy Time: " + health.ControllerBusyTime);
       r.AppendLine("Power Cycles: " + health.PowerCycle);
       r.AppendLine("Power On Hours: " + health.PowerOnHours);
@@ -159,13 +160,13 @@ namespace OpenHardwareMonitor.Hardware.HDD {
       for (int i=0; i<health.TemperatureSensors.Length; i++) {
         if (health.TemperatureSensors[i] > short.MinValue)
           r.AppendLine("Temperature Sensor " + (i + 1) + ": " + health.TemperatureSensors[i] + " Celsius");
-      }                                               
+      }
     }
 
     public override void Close() {
       smart.Close();
       
       base.Close();
-    }    
+    }
   }
 }

--- a/Hardware/HDD/NVMeGeneric.cs
+++ b/Hardware/HDD/NVMeGeneric.cs
@@ -1,0 +1,171 @@
+﻿/*
+ 
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ 
+  Copyright (C) 2017 Alexander Thulcke <alexth4ef9@gmail.com>
+  
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OpenHardwareMonitor.Hardware.HDD {
+  internal sealed class NVMeGeneric : AbstractStorage {
+    private delegate float GetSensorValue(NVMeHealthInfo health);
+    
+    private class NVMeSensor : Sensor {
+      private readonly GetSensorValue getValue;
+      
+      public NVMeSensor(string name, int index, bool defaultHidden, 
+        SensorType sensorType, Hardware hardware, ISettings settings,
+        GetSensorValue getValue)
+        : base(name, index, defaultHidden, sensorType, hardware, null, settings)
+      {        
+        this.getValue = getValue;
+      }
+
+      public void Update(NVMeHealthInfo health) {
+        Value = getValue(health);
+      }
+    }
+
+    private const int MAX_DRIVES = 32;
+    
+    private static Dictionary<string, NVMeInfo> serialToInfo;
+    private readonly WindowsNVMeSmart smart;
+    private readonly NVMeInfo info;
+    private List<NVMeSensor> sensors = new List<NVMeSensor>();
+        
+    private NVMeGeneric(NVMeInfo info, int index, ISettings settings)
+      : base(info.Model, info.Revision, "nvme", index, settings)
+    {
+      this.smart = new WindowsNVMeSmart(info.Index);
+      this.info = info;
+      CreateSensors();
+    }
+     
+    // \\.\ScsiY: is different from \\.\PhysicalDriveX, user serial number for mapping     
+    private static NVMeInfo GetDeviceInfo(string serial) {
+      if (serialToInfo == null) {
+        serialToInfo = new Dictionary<string, NVMeInfo>();
+        for (int drive = 0; drive < MAX_DRIVES; drive++) {
+          using(WindowsNVMeSmart smart = new WindowsNVMeSmart(drive)) {
+            if (!smart.IsValid)
+              continue;
+            NVMeInfo info = smart.GetInfo();
+            if (info != null)
+              serialToInfo.Add(info.Serial, info);
+          }
+        }
+      }
+      NVMeInfo result;
+      return serialToInfo.TryGetValue(serial, out result) ? result : null;
+    }
+    
+    public static AbstractStorage CreateInstance(StorageInfo storageInfo, ISettings settings) {
+      NVMeInfo nvmeInfo = GetDeviceInfo(storageInfo.Serial);
+      if (nvmeInfo == null)
+        return null;
+      return new NVMeGeneric(nvmeInfo, storageInfo.Index, settings);
+    }
+            
+    protected override void CreateSensors() {
+      AddSensor("Temperature", 0, false, SensorType.Temperature, (health) => health.Temperature);
+      AddSensor("Available Spare", 0, false, SensorType.Level, (health) => health.AvailableSpare);
+      AddSensor("Available Spare Threshold", 1, false, SensorType.Level, (health) => health.AvailableSpareThreshold);
+      AddSensor("Percentage Used", 2, false, SensorType.Level, (health) => health.PercentageUsed);
+      AddSensor("Data Read", 1, false, SensorType.Data, (health) => UnitsToData(health.DataUnitRead));
+      AddSensor("Data Written", 2, false, SensorType.Data, (health) => UnitsToData(health.DataUnitWritten));
+      NVMeHealthInfo log = smart.GetHealthInfo();
+      for (int i=0; i<log.TemperatureSensors.Length; i++) {
+        if (log.TemperatureSensors[i] > short.MinValue)
+          AddSensor("Temperature", i + 1, true, SensorType.Temperature, (health) => health.TemperatureSensors[i]);
+      }
+
+      base.CreateSensors();
+    }
+    
+    private void AddSensor(string name, int index, bool defaultHidden, 
+      SensorType sensorType, GetSensorValue getValue)
+    {
+      NVMeSensor sensor = new NVMeSensor(name, index, defaultHidden, sensorType, this, settings, getValue);
+      ActivateSensor(sensor);
+      sensors.Add(sensor);
+    }
+
+    static readonly ulong Units = 512;
+    static readonly ulong Scale = 1000000;
+    
+    private static float UnitsToData(ulong u) {
+      // one unit is 512 * 1000 bytes, return in GB (not GiB)
+      return ((Units * u) / Scale);
+    }
+    
+    protected override void UpdateSensors() {
+      NVMeHealthInfo health = smart.GetHealthInfo();
+      foreach(NVMeSensor sensor in sensors)
+        sensor.Update(health);
+    }
+    
+    protected override void GetReport(StringBuilder r) {
+      r.AppendLine("PCI Vendor ID: 0x" + info.VID.ToString("x04"));
+      if (info.VID != info.SSVID)
+        r.AppendLine("PCI Subsystem Vendor ID: 0x" + info.VID.ToString("x04"));
+      r.AppendLine("IEEE OUI Identifier: 0x" + info.IEEE[2].ToString("x02") + info.IEEE[1].ToString("x02") + info.IEEE[0].ToString("x02"));
+      r.AppendLine("Total NVM Capacity: " + info.TotalCapacity);
+      r.AppendLine("Unallocated NVM Capacity: " + info.UnallocatedCapacity);
+      r.AppendLine("Controller ID: " + info.ControllerId);
+      r.AppendLine("Number of Namespaces: " + info.NumberNamespaces);
+      if (info.Namespace1 != null) {
+        r.AppendLine("Namespace 1 Size: " + info.Namespace1.Size);
+        r.AppendLine("Namespace 1 Capacity: " + info.Namespace1.Capacity);
+        r.AppendLine("Namespace 1 Utilization: " + info.Namespace1.Utilization);
+        r.AppendLine("Namespace 1 LBA Data Size: " + info.Namespace1.LBADataSize);
+      }
+      
+      NVMeHealthInfo health = smart.GetHealthInfo();
+      if (health.CriticalWarning == NVMeCriticalWarning.None)
+        r.AppendLine("Critical Warning: -");
+      else {
+        if ((health.CriticalWarning & NVMeCriticalWarning.AvailableSpaceLow) != 0)
+          r.AppendLine("Critical Warning: the available spare space has fallen below the threshold.");
+        if ((health.CriticalWarning & NVMeCriticalWarning.TemperatureThreshold) != 0)
+          r.AppendLine("Critical Warning: a temperature is above an over temperature threshold or below an under temperature threshold.");
+        if ((health.CriticalWarning & NVMeCriticalWarning.ReliabilityDegraded) != 0)
+          r.AppendLine("Critical Warning: the device reliability has been degraded due to significant media related errors or any internal error that degrades device reliability.");
+        if ((health.CriticalWarning & NVMeCriticalWarning.ReadOnly) != 0)
+          r.AppendLine("Critical Warning: the media has been placed in read only mode.");
+        if ((health.CriticalWarning & NVMeCriticalWarning.VolatileMemoryBackupDeviceFailed) != 0)
+          r.AppendLine("Critical Warning: the volatile memory backup device has failed.");
+      }
+      r.AppendLine("Temperature: " + health.Temperature +" Celsius");
+      r.AppendLine("Available Spare: " + health.AvailableSpare +"%");
+      r.AppendLine("Available Spare Threshold: " + health.AvailableSpareThreshold +"%");
+      r.AppendLine("Data Units Read: " + health.DataUnitRead);
+      r.AppendLine("Data Units Written: " + health.DataUnitWritten);
+      r.AppendLine("Host Read Commands: " + health.HostReadCommands);
+      r.AppendLine("Data Write Commands: " + health.HostWrittenCommands);
+      r.AppendLine("Controller Busy Time: " + health.ControllerBusyTime);
+      r.AppendLine("Power Cycles: " + health.PowerCycle);
+      r.AppendLine("Power On Hours: " + health.PowerOnHours);
+      r.AppendLine("Unsafe Shutdowns: " + health.UnsafeShutdowns);
+      r.AppendLine("Media Errors: " + health.MediaErrors);
+      r.AppendLine("Number of Error Information Log Entries: " + health.ErrorInfoLogEntryCount);
+      r.AppendLine("Warning Composite Temperature Time: " + health.WarningCompositeTemperatureTime);
+      r.AppendLine("Critical Composite Temperature Time: " + health.CriticalCompositeTemperatureTime);
+      for (int i=0; i<health.TemperatureSensors.Length; i++) {
+        if (health.TemperatureSensors[i] > short.MinValue)
+          r.AppendLine("Temperature Sensor " + (i + 1) + ": " + health.TemperatureSensors[i] + " Celsius");
+      }                                               
+    }
+
+    public override void Close() {
+      smart.Close();
+      
+      base.Close();
+    }    
+  }
+}

--- a/Hardware/HDD/NVMeGeneric.cs
+++ b/Hardware/HDD/NVMeGeneric.cs
@@ -78,8 +78,10 @@ namespace OpenHardwareMonitor.Hardware.HDD {
       AddSensor("Data Written", 2, false, SensorType.Data, (health) => UnitsToData(health.DataUnitWritten));
       NVMeHealthInfo log = smart.GetHealthInfo();
       for (int i=0; i<log.TemperatureSensors.Length; i++) {
-        if (log.TemperatureSensors[i] > short.MinValue)
-          AddSensor("Temperature", i + 1, true, SensorType.Temperature, (health) => health.TemperatureSensors[i]);
+        if (log.TemperatureSensors[i] > short.MinValue) {
+          int idx = i;
+          AddSensor("Temperature", i + 1, true, SensorType.Temperature, (health) => health.TemperatureSensors[idx]);
+        }
       }
 
       base.CreateSensors();

--- a/Hardware/HDD/SSDIndilinx.cs
+++ b/Hardware/HDD/SSDIndilinx.cs
@@ -15,7 +15,7 @@ namespace OpenHardwareMonitor.Hardware.HDD {
 
   [NamePrefix(""), RequireSmart(0x01), RequireSmart(0x09), RequireSmart(0x0C), 
     RequireSmart(0xD1), RequireSmart(0xCE), RequireSmart(0xCF)]
-  internal class SSDIndilinx : AbstractHarddrive {
+  internal class SSDIndilinx : ATAStorage {
 
     private static readonly IEnumerable<SmartAttribute> smartAttributes =
       new List<SmartAttribute> {
@@ -46,7 +46,7 @@ namespace OpenHardwareMonitor.Hardware.HDD {
 
     public SSDIndilinx(ISmart smart, string name, string firmwareRevision, 
       int index, ISettings settings)
-      : base(smart, name, firmwareRevision, index, smartAttributes, settings) {}
+      : base(smart, name, firmwareRevision, "ssd", index, smartAttributes, settings) {}
   }
 }
 

--- a/Hardware/HDD/SSDIntel.cs
+++ b/Hardware/HDD/SSDIntel.cs
@@ -17,7 +17,7 @@ namespace OpenHardwareMonitor.Hardware.HDD {
    
   [NamePrefix("INTEL SSD"), 
    RequireSmart(0xE1), RequireSmart(0xE8), RequireSmart(0xE9)]
-  internal class SSDIntel : AbstractHarddrive {
+  internal class SSDIntel : ATAStorage {
 
     private static readonly IEnumerable<SmartAttribute> smartAttributes =
       new List<SmartAttribute> {
@@ -52,6 +52,6 @@ namespace OpenHardwareMonitor.Hardware.HDD {
 
     public SSDIntel(ISmart smart, string name, string firmwareRevision, 
       int index, ISettings settings)
-      : base(smart, name, firmwareRevision, index, smartAttributes, settings) {}
+      : base(smart, name, firmwareRevision, "ssd", index, smartAttributes, settings) {}
   }
 }

--- a/Hardware/HDD/SSDMicron.cs
+++ b/Hardware/HDD/SSDMicron.cs
@@ -15,7 +15,7 @@ namespace OpenHardwareMonitor.Hardware.HDD {
 
   [NamePrefix(""), RequireSmart(0xAA), RequireSmart(0xAB), RequireSmart(0xAC), 
    RequireSmart(0xAD), RequireSmart(0xAE), RequireSmart(0xCA)]
-  internal class SSDMicron : AbstractHarddrive {
+  internal class SSDMicron : ATAStorage {
 
     private static readonly IEnumerable<SmartAttribute> smartAttributes =
       new List<SmartAttribute> {
@@ -51,6 +51,6 @@ namespace OpenHardwareMonitor.Hardware.HDD {
 
     public SSDMicron(ISmart smart, string name, string firmwareRevision, 
       int index, ISettings settings)
-      : base(smart, name, firmwareRevision, index, smartAttributes, settings) {}
+      : base(smart, name, firmwareRevision, "ssd", index, smartAttributes, settings) {}
   }
 }

--- a/Hardware/HDD/SSDPlextor.cs
+++ b/Hardware/HDD/SSDPlextor.cs
@@ -8,12 +8,12 @@
 	
 */
 
-namespace OpenHardwareMonitor.Hardware.HDD {
-  using System.Collections.Generic;
-  using OpenHardwareMonitor.Collections;
+using System.Collections.Generic;
+using OpenHardwareMonitor.Collections;
 
+namespace OpenHardwareMonitor.Hardware.HDD {
   [NamePrefix("PLEXTOR")]
-  internal class SSDPlextor : AbstractHarddrive {
+  internal class SSDPlextor : ATAStorage {
 
     private static readonly IEnumerable<SmartAttribute> smartAttributes =
       new List<SmartAttribute> {
@@ -27,7 +27,7 @@ namespace OpenHardwareMonitor.Hardware.HDD {
 
     public SSDPlextor(ISmart smart, string name, string firmwareRevision, 
       int index, ISettings settings)
-      : base(smart, name, firmwareRevision, index, smartAttributes, settings) {}
+      : base(smart, name, firmwareRevision, "ssd", index, smartAttributes, settings) {}
 
     private static float RawToGb(byte[] rawvalue, byte value,
       IReadOnlyArray<IParameter> parameters) 

--- a/Hardware/HDD/SSDSamsung.cs
+++ b/Hardware/HDD/SSDSamsung.cs
@@ -8,14 +8,14 @@
 	
 */
 
-namespace OpenHardwareMonitor.Hardware.HDD {
-  using System.Collections.Generic;
-  using OpenHardwareMonitor.Collections;
+using System.Collections.Generic;
+using OpenHardwareMonitor.Collections;
 
+namespace OpenHardwareMonitor.Hardware.HDD {
   [NamePrefix(""), RequireSmart(0xB1), RequireSmart(0xB3), RequireSmart(0xB5),
     RequireSmart(0xB6), RequireSmart(0xB7), RequireSmart(0xBB), 
     RequireSmart(0xC3), RequireSmart(0xC7)]
-  internal class SSDSamsung : AbstractHarddrive {
+  internal class SSDSamsung : ATAStorage {
 
     private static readonly IEnumerable<SmartAttribute> smartAttributes =
       new List<SmartAttribute> {
@@ -60,6 +60,6 @@ namespace OpenHardwareMonitor.Hardware.HDD {
 
     public SSDSamsung(ISmart smart, string name, string firmwareRevision,
       int index, ISettings settings)
-      : base(smart, name, firmwareRevision, index, smartAttributes, settings) { }
+      : base(smart, name, firmwareRevision, "ssd", index, smartAttributes, settings) { }
   }
 }

--- a/Hardware/HDD/SSDSandforce.cs
+++ b/Hardware/HDD/SSDSandforce.cs
@@ -15,7 +15,7 @@ using OpenHardwareMonitor.Collections;
 namespace OpenHardwareMonitor.Hardware.HDD {
 
   [NamePrefix(""), RequireSmart(0xAB), RequireSmart(0xB1)]
-  internal class SSDSandforce : AbstractHarddrive {
+  internal class SSDSandforce : ATAStorage {
 
     private static readonly IEnumerable<SmartAttribute> smartAttributes =
       new List<SmartAttribute> {
@@ -55,7 +55,7 @@ namespace OpenHardwareMonitor.Hardware.HDD {
 
     public SSDSandforce(ISmart smart, string name, string firmwareRevision, 
       int index, ISettings settings) 
-      : base(smart, name, firmwareRevision,  index, smartAttributes, settings) 
+      : base(smart, name, firmwareRevision, "ssd", index, smartAttributes, settings) 
     {
       this.writeAmplification = new Sensor("Write Amplification", 1, 
         SensorType.Factor, this, settings);    

--- a/Hardware/HDD/StorageGeneric.cs
+++ b/Hardware/HDD/StorageGeneric.cs
@@ -1,0 +1,34 @@
+﻿/*
+ 
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ 
+  Copyright (C) 2017 Alexander Thulcke <alexth4ef9@gmail.com>
+  
+*/
+
+using System;
+using System.Text;
+
+namespace OpenHardwareMonitor.Hardware.HDD {
+  internal sealed class StorageGeneric : AbstractStorage {    
+    private StorageGeneric(string name, string firmwareRevision, int index, ISettings settings)
+      : base(name, firmwareRevision, "hdd", index, settings)
+    {
+      CreateSensors();
+    }
+    
+    public static AbstractStorage CreateInstance(StorageInfo info, ISettings settings) {
+      string name = string.IsNullOrEmpty(info.Name) ? "Generic Hard Disk" : info.Name;
+      string firmwareRevision = string.IsNullOrEmpty(info.Revision) ? "Unknown" : info.Revision;      
+      return new StorageGeneric(name, firmwareRevision, info.Index, settings);
+    }
+        
+    protected override void UpdateSensors() {      
+    }
+    
+    protected override void GetReport(StringBuilder r) {      
+    }
+  }
+}

--- a/Hardware/HDD/WindowsNVMeSmart.cs
+++ b/Hardware/HDD/WindowsNVMeSmart.cs
@@ -376,7 +376,7 @@ namespace OpenHardwareMonitor.Hardware.HDD {
       return Encoding.ASCII.GetString(s).Trim('\t', '\n', '\r', ' ', '\0');
     }
     
-    // should use BitInteger from .NET 4.0, 128-bit integers
+    // should use BigInteger from .NET 4.0, 128-bit integers
     private static ulong ShiftValue(ulong v, byte s) {
       ulong low = v << s;
       //ulong high = v >> (64 - s);
@@ -430,8 +430,7 @@ namespace OpenHardwareMonitor.Hardware.HDD {
           return new NVMeInfoImpl(driveNumber, data, rawData, nspace, rawDataNamespace);
         }
         return new NVMeInfoImpl(driveNumber, data, rawData);
-      } catch(Win32Exception e) {
-        Console.WriteLine(e);
+      } catch(Win32Exception) {
       }
       return null;
     }

--- a/Hardware/HDD/WindowsNVMeSmart.cs
+++ b/Hardware/HDD/WindowsNVMeSmart.cs
@@ -22,7 +22,7 @@ namespace OpenHardwareMonitor.Hardware.HDD {
     public ulong Size { get; protected set; }
     public ulong Capacity { get; protected set; }
     public ulong Utilization { get; protected set; }
-    public uint LBADataSize { get; protected set; }      
+    public uint LBADataSize { get; protected set; }
     public byte[] RawData { get; protected set; }
   }
   
@@ -47,12 +47,12 @@ namespace OpenHardwareMonitor.Hardware.HDD {
     None = 0x00,
     AvailableSpaceLow = 0x01, // If set to 1, then the available spare space has fallen below the threshold.
     TemperatureThreshold = 0x02, // If set to 1, then a temperature is above an over temperature threshold or below an under temperature threshold.
-    ReliabilityDegraded = 0x04, // If set to 1, then the device reliability has been degraded due to significant media related  errors or any internal error that degrades device reliability.
+    ReliabilityDegraded = 0x04, // If set to 1, then the device reliability has been degraded due to significant media related errors or any internal error that degrades device reliability.
     ReadOnly = 0x08, // If set to 1, then the media has been placed in read only mode
     VolatileMemoryBackupDeviceFailed = 0x10, // If set to 1, then the volatile memory backup device has failed. This field is only valid if the controller has a volatile memory backup solution.
   }
 
-  internal abstract class NVMeHealthInfo {    
+  internal abstract class NVMeHealthInfo {
     public NVMeCriticalWarning CriticalWarning { get; protected set; }
     public short Temperature { get; protected set; }
     public byte AvailableSpare { get; protected set; }
@@ -61,7 +61,7 @@ namespace OpenHardwareMonitor.Hardware.HDD {
     public ulong DataUnitRead { get; protected set; }
     public ulong DataUnitWritten { get; protected set; }
     public ulong HostReadCommands { get; protected set; }
-    public ulong HostWrittenCommands { get; protected set; }
+    public ulong HostWriteCommands { get; protected set; }
     public ulong ControllerBusyTime { get; protected set; }
     public ulong PowerCycle { get; protected set; }
     public ulong PowerOnHours { get; protected set; }
@@ -138,117 +138,117 @@ namespace OpenHardwareMonitor.Hardware.HDD {
     
     [StructLayout(LayoutKind.Sequential)]
     private struct NVMePowerStateDesc {
-      public ushort mp; // bit 0:15.    Maximum  Power (MP) in centiwatts
+      public ushort mp; // bit 0:15 Maximum  Power (MP) in centiwatts
       public byte Reserved0; // bit 16:23
-      public byte mps_nops; // bit 24: Max Power Scale (MPS), bit 25: Non-Operational State (NOPS)
-      public uint enlat; // bit 32:63.   Entry Latency (ENLAT) in microseconds
-      public uint exlat; // bit 64:95.   Exit Latency (EXLAT) in microseconds
-      public byte rrt; // bit 96:100.  Relative Read Throughput (RRT)
-      public byte rrl; // bit 104:108  Relative Read Latency (RRL)
-      public byte rwt; // bit 112:116  Relative Write Throughput (RWT)
-      public byte rwl; // bit 120:124  Relative Write Latency (RWL)
-      public ushort idlp; // bit 128:143  Idle Power (IDLP)
-      public byte ips; // bit 150:151  Idle Power Scale (IPS)
+      public byte mps_nops; // bit 24 Max Power Scale (MPS), bit 25 Non-Operational State (NOPS)
+      public uint enlat; // bit 32:63 Entry Latency (ENLAT) in microseconds
+      public uint exlat; // bit 64:95 Exit Latency (EXLAT) in microseconds
+      public byte rrt; // bit 96:100 Relative Read Throughput (RRT)
+      public byte rrl; // bit 104:108 Relative Read Latency (RRL)
+      public byte rwt; // bit 112:116 Relative Write Throughput (RWT)
+      public byte rwl; // bit 120:124 Relative Write Latency (RWL)
+      public ushort idlp; // bit 128:143 Idle Power (IDLP)
+      public byte ips; // bit 150:151 Idle Power Scale (IPS)
       public byte Reserved7; // bit 152:159
-      public ushort actp; // bit 160:175  Active Power (ACTP)
-      public byte apw_aps; // bit 176:178  Active Power Workload (APW), bit 182:183  Active Power Scale (APS)
+      public ushort actp; // bit 160:175 Active Power (ACTP)
+      public byte apw_aps; // bit 176:178 Active Power Workload (APW), bit 182:183  Active Power Scale (APS)
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 9)]
-      public byte[] Reserved9;       // bit 184:255.
+      public byte[] Reserved9; // bit 184:255.
     }
     
     [StructLayout(LayoutKind.Sequential)]
     private struct NVMeIdentifyControllerData {
-      public ushort vid; // byte 0:1.    M - PCI Vendor ID (VID)
-      public ushort ssvid; // byte 2:3.    M - PCI Subsystem Vendor ID (SSVID)
+      public ushort vid; // byte 0:1 M - PCI Vendor ID (VID)
+      public ushort ssvid; // byte 2:3 M - PCI Subsystem Vendor ID (SSVID)
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 20)]
-      public byte[] sn; // byte 4: 23.  M - Serial Number (SN)
+      public byte[] sn; // byte 4: 23 M - Serial Number (SN)
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 40)]
-      public byte[] mn; // byte 24:63.  M - Model Number (MN)
+      public byte[] mn; // byte 24:63 M - Model Number (MN)
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 8)]
-      public byte[] fr; // byte 64:71.  M - Firmware Revision (FR)
-      public byte rab; // byte 72.     M - Recommended Arbitration Burst (RAB)
+      public byte[] fr; // byte 64:71 M - Firmware Revision (FR)
+      public byte rab; // byte 72 M - Recommended Arbitration Burst (RAB)
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 3)]
-      public byte[] ieee; // byte 73:75.  M - IEEE OUI Identifier (IEEE). Controller Vendor code.
-      public byte cmic; // byte 76.     O - Controller Multi-Path I/O and Namespace Sharing Capabilities (CMIC)
-      public byte mdts; // byte 77.     M - Maximum Data Transfer Size (MDTS)
-      public ushort cntlid; // byte 78:79.   M - Controller ID (CNTLID)
-      public uint ver; // byte 80:83.   M - Version (VER)
-      public uint rtd3r; // byte 84:87.   M - RTD3 Resume Latency (RTD3R)
-      public uint rtd3e; // byte 88:91.   M - RTD3 Entry Latency (RTD3E)
-      public uint oaes; // byte 92:95.   M - Optional Asynchronous Events Supported (OAES)
+      public byte[] ieee; // byte 73:75 M - IEEE OUI Identifier (IEEE). Controller Vendor code.
+      public byte cmic; // byte 76 O - Controller Multi-Path I/O and Namespace Sharing Capabilities (CMIC)
+      public byte mdts; // byte 77 M - Maximum Data Transfer Size (MDTS)
+      public ushort cntlid; // byte 78:79 M - Controller ID (CNTLID)
+      public uint ver; // byte 80:83 M - Version (VER)
+      public uint rtd3r; // byte 84:87 M - RTD3 Resume Latency (RTD3R)
+      public uint rtd3e; // byte 88:91 M - RTD3 Entry Latency (RTD3E)
+      public uint oaes; // byte 92:95 M - Optional Asynchronous Events Supported (OAES)
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 144)]
       public byte[] Reserved0; // byte 96:239.
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
       public byte[] ReservedForManagement; // byte 240:255.  Refer to the NVMe Management Interface Specification for definition.
-      public ushort oacs; // byte 256:257. M - Optional Admin Command Support (OACS)
-      public byte acl; // byte 258.    M - Abort Command Limit (ACL)
-      public byte aerl; // byte 259.    M - Asynchronous Event Request Limit (AERL)
-      public byte frmw; // byte 260.    M - Firmware Updates (FRMW)
-      public byte lpa; // byte 261.    M - Log Page Attributes (LPA)
-      public byte elpe; // byte 262.    M - Error Log Page Entries (ELPE)
-      public byte npss; // byte 263.    M - Number of Power States Support (NPSS)
-      public byte avscc; // byte 264.    M - Admin Vendor Specific Command Configuration (AVSCC)
-      public byte apsta; // byte 265.     O - Autonomous Power State Transition Attributes (APSTA)
-      public ushort wctemp; // byte 266:267. M - Warning Composite Temperature Threshold (WCTEMP)
-      public ushort cctemp; // byte 268:269. M - Critical Composite Temperature Threshold (CCTEMP)
-      public ushort mtfa; // byte 270:271. O - Maximum Time for Firmware Activation (MTFA)
-      public uint hmpre; // byte 272:275. O - Host Memory Buffer Preferred Size (HMPRE)
-      public uint hmmin; // byte 276:279. O - Host Memory Buffer Minimum Size (HMMIN)
+      public ushort oacs; // byte 256:257 M - Optional Admin Command Support (OACS)
+      public byte acl; // byte 258 M - Abort Command Limit (ACL)
+      public byte aerl; // byte 259 M - Asynchronous Event Request Limit (AERL)
+      public byte frmw; // byte 260 M - Firmware Updates (FRMW)
+      public byte lpa; // byte 261 M - Log Page Attributes (LPA)
+      public byte elpe; // byte 262 M - Error Log Page Entries (ELPE)
+      public byte npss; // byte 263 M - Number of Power States Support (NPSS)
+      public byte avscc; // byte 264 M - Admin Vendor Specific Command Configuration (AVSCC)
+      public byte apsta; // byte 265 O - Autonomous Power State Transition Attributes (APSTA)
+      public ushort wctemp; // byte 266:267 M - Warning Composite Temperature Threshold (WCTEMP)
+      public ushort cctemp; // byte 268:269 M - Critical Composite Temperature Threshold (CCTEMP)
+      public ushort mtfa; // byte 270:271 O - Maximum Time for Firmware Activation (MTFA)
+      public uint hmpre; // byte 272:275 O - Host Memory Buffer Preferred Size (HMPRE)
+      public uint hmmin; // byte 276:279 O - Host Memory Buffer Minimum Size (HMMIN)
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
-      public byte[] tnvmcap; // byte 280:295. O - Total NVM Capacity (TNVMCAP)
+      public byte[] tnvmcap; // byte 280:295 O - Total NVM Capacity (TNVMCAP)
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
-      public byte[] unvmcap; // byte 296:311. O - Unallocated NVM Capacity (UNVMCAP)
-      public uint rpmbs; // byte 312:315. O - Replay Protected Memory Block Support (RPMBS)
+      public byte[] unvmcap; // byte 296:311 O - Unallocated NVM Capacity (UNVMCAP)
+      public uint rpmbs; // byte 312:315 O - Replay Protected Memory Block Support (RPMBS)
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 196)]
-      public byte[] Reserved1; // byte 316:511.
-      public byte sqes; // byte 512.    M - Submission Queue Entry Size (SQES)
-      public byte cqes; // byte 513.    M - Completion Queue Entry Size (CQES)
+      public byte[] Reserved1; // byte 316:511
+      public byte sqes; // byte 512 M - Submission Queue Entry Size (SQES)
+      public byte cqes; // byte 513 M - Completion Queue Entry Size (CQES)
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 2)]
-      public byte[] Reserved2; // byte 514:515.
-      public uint nn; // byte 516:519. M - Number of Namespaces (NN)
-      public ushort oncs; // byte 520:521. M - Optional NVM Command Support (ONCS)
-      public ushort fuses; // byte 522:523. M - Fused Operation Support (FUSES)
-      public byte fna; // byte 524.     M - Format NVM Attributes (FNA)
-      public byte vwc; // byte 525.     M - Volatile Write Cache (VWC)
-      public ushort awun; // byte 526:527. M - Atomic Write Unit Normal (AWUN)
-      public ushort awupf; // byte 528:529. M - Atomic Write Unit Power Fail (AWUPF)
-      public byte nvscc; // byte 530.     M - NVM Vendor Specific Command Configuration (NVSCC)
-      public byte Reserved3; // byte 531.
-      public ushort acwu; // byte 532:533  O - Atomic Compare & Write Unit (ACWU)
+      public byte[] Reserved2; // byte 514:515
+      public uint nn; // byte 516:519 M - Number of Namespaces (NN)
+      public ushort oncs; // byte 520:521 M - Optional NVM Command Support (ONCS)
+      public ushort fuses; // byte 522:523 M - Fused Operation Support (FUSES)
+      public byte fna; // byte 524 M - Format NVM Attributes (FNA)
+      public byte vwc; // byte 525 M - Volatile Write Cache (VWC)
+      public ushort awun; // byte 526:527 M - Atomic Write Unit Normal (AWUN)
+      public ushort awupf; // byte 528:529 M - Atomic Write Unit Power Fail (AWUPF)
+      public byte nvscc; // byte 530 M - NVM Vendor Specific Command Configuration (NVSCC)
+      public byte Reserved3; // byte 531
+      public ushort acwu; // byte 532:533 O - Atomic Compare & Write Unit (ACWU)
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 2)]
-      public byte[] Reserved4; // byte 534:535.
-      public uint sgls; // byte 536:539. O - SGL Support (SGLS)
+      public byte[] Reserved4; // byte 534:535
+      public uint sgls; // byte 536:539 O - SGL Support (SGLS)
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 164)]
-      public byte[] Reserved5; // byte 540:703.
-      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 1344)]    
-      public byte[] Reserved6; // byte 704:2047.
+      public byte[] Reserved5; // byte 540:703
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 1344)]
+      public byte[] Reserved6; // byte 704:2047
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
-      public NVMePowerStateDesc[] pds; // byte 2048 : 3071, Power State Descriptors
+      public NVMePowerStateDesc[] pds; // byte 2048:3071 Power State Descriptors
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 1024)]
-      public byte[] vs; // byte 3072 : 4095, Vendor Specific
+      public byte[] vs; // byte 3072:4095 Vendor Specific
     }
         
     [StructLayout(LayoutKind.Sequential)]
     private struct NVMeLBAFormat {
-      public ushort ms; // bit 0:15     Metadata Size (MS)
-      public byte lbads; // bit 16:23    LBA  Data  Size (LBADS)
-      public byte rp; // bit 24:25    Relative Performance (RP)
+      public ushort ms; // bit 0:15 Metadata Size (MS)
+      public byte lbads; // bit 16:23 LBA  Data  Size (LBADS)
+      public byte rp; // bit 24:25 Relative Performance (RP)
     }
 
     [StructLayout(LayoutKind.Sequential)]
     private struct NVMeIdentifyNamespaceData {
-      public ulong nsze; // byte 0:7.    M - Namespace Size (NSZE)
-      public ulong ncap; // byte 8:15    M - Namespace Capacity (NCAP)
-      public ulong nuse; // byte 16:23   M - Namespace Utilization (NUSE)
-      public byte nsfeat; // byte 24      M - Namespace Features (NSFEAT)
-      public byte nlbaf; // byte 25      M - Number of LBA Formats (NLBAF)
-      public byte flbas; // byte 26      M - Formatted LBA Size (FLBAS)
-      public byte mc; // byte 27      M - Metadata Capabilities (MC)
-      public byte dpc; // byte 28      M - End-to-end Data Protection Capabilities (DPC)
-      public byte dps; // byte 29      M - End-to-end Data Protection Type Settings (DPS)
-      public byte nmic; // byte 30      O - Namespace Multi-path I/O and Namespace Sharing Capabilities (NMIC)
-      public byte rescap; // byte 31      O - Reservation Capabilities (RESCAP)
-      public byte fpi; // byte 32      O - Format Progress Indicator (FPI)
+      public ulong nsze; // byte 0:7 M - Namespace Size (NSZE)
+      public ulong ncap; // byte 8:15 M - Namespace Capacity (NCAP)
+      public ulong nuse; // byte 16:23 M - Namespace Utilization (NUSE)
+      public byte nsfeat; // byte 24 M - Namespace Features (NSFEAT)
+      public byte nlbaf; // byte 25 M - Number of LBA Formats (NLBAF)
+      public byte flbas; // byte 26 M - Formatted LBA Size (FLBAS)
+      public byte mc; // byte 27 M - Metadata Capabilities (MC)
+      public byte dpc; // byte 28 M - End-to-end Data Protection Capabilities (DPC)
+      public byte dps; // byte 29 M - End-to-end Data Protection Type Settings (DPS)
+      public byte nmic; // byte 30 O - Namespace Multi-path I/O and Namespace Sharing Capabilities (NMIC)
+      public byte rescap; // byte 31 O - Reservation Capabilities (RESCAP)
+      public byte fpi; // byte 32 O - Format Progress Indicator (FPI)
       public byte Reserved0; // byte 33
       public ushort nawun; // byte 34:35 O - Namespace Atomic Write Unit Normal (NAWUN)
       public ushort nawupf;// byte 36:37 O - Namespace Atomic Write Unit Power Fail (NAWUPF)
@@ -257,12 +257,12 @@ namespace OpenHardwareMonitor.Hardware.HDD {
       public ushort nabo; // byte 42:43 O - Namespace Atomic Boundary Offset (NABO)
       public ushort nabspf; // byte 44:45 O - Namespace Atomic Boundary Size Power Fail (NABSPF)
       public ushort Reserved1; // byte 46:47
-      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]      
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
       public byte[] nvmcap; // byte 48:63 O - NVM Capacity (NVMCAP)
-      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 40)]      
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 40)]
       public byte[] Reserved2; // byte 64:103
-      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]      
-      public byte[] nguid; // byte 104:119 O - NAmespace Globally Unique Identifier (NGUID)
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+      public byte[] nguid; // byte 104:119 O - Namespace Globally Unique Identifier (NGUID)
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 8)]
       public byte[] eui64; // byte 120:127 M - IEEE Extended Unique Identifier (EUI64)
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
@@ -270,7 +270,7 @@ namespace OpenHardwareMonitor.Hardware.HDD {
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 192)]
       public byte[] Reserved3;     // byte 192:383
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 3712)]
-      public byte[] vs; // byte 384:4095 O - Vendor Specific (VS): This range of bytes is allocated for vendor specific usage.      
+      public byte[] vs; // byte 384:4095 O - Vendor Specific (VS): This range of bytes is allocated for vendor specific usage.
     }
     
     private class NVMeNamespaceInfoImpl : NVMeNamespaceInfo {
@@ -292,17 +292,17 @@ namespace OpenHardwareMonitor.Hardware.HDD {
         Serial = GetString(data.sn);
         Model = GetString(data.mn);
         Revision = GetString(data.fr);
-        IEEE = data.ieee;        
+        IEEE = data.ieee;
         TotalCapacity = BitConverter.ToUInt64(data.tnvmcap, 0); // 128bit little endian
         UnallocatedCapacity = BitConverter.ToUInt64(data.unvmcap, 0);
         ControllerId = data.cntlid;
         NumberNamespaces = data.nn;
         RawData = rawData;
-      }      
+      }
     
       public NVMeInfoImpl(int index, NVMeIdentifyControllerData data, byte[] rawData,
         NVMeIdentifyNamespaceData namespaceData, byte[] namespaceRawData)
-        : this(index, data, rawData) 
+        : this(index, data, rawData)
       {
         Namespace1 = new NVMeNamespaceInfoImpl(namespaceData, namespaceRawData);
       }
@@ -312,51 +312,51 @@ namespace OpenHardwareMonitor.Hardware.HDD {
     private struct NVMeHealthInfoLog {
       public byte CriticalWarning; // This field indicates critical warnings for the state of the  controller. Each bit corresponds to a critical warning type; multiple bits may be set.
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 2)]
-      public byte[] Temperature; // Temperature: Contains the temperature of the overall device (controller and NVM included) in units of Kelvin. If the temperature exceeds the temperature threshold, refer to section 5.12.1.4, then an asynchronous event completion may occur
+      public byte[] CompositeTemperature; // Composite Temperature:  Contains the temperature of the overall device (controller and NVM included) in units of Kelvin.
       public byte AvailableSpare; // Available Spare:  Contains a normalized percentage (0 to 100%) of the remaining spare capacity available
-      public byte AvailableSpareThreshold; // Available Spare Threshold:  When the Available Spare falls below the threshold indicated in this field, an asynchronous event  completion may occur. The value is indicated as a normalized percentage (0 to 100%).
-      public byte PercentageUsed; // Percentage Used
+      public byte AvailableSpareThreshold; // Available Spare Threshold:  When the Available Spare falls below the threshold indicated in this field, an asynchronous event completion may occur. The value is indicated as a normalized percentage (0 to 100%).
+      public byte PercentageUsed; // Percentage Used:  Contains a vendor specific estimate of the percentage of NVM subsystem life used based on the actual usage and the manufacturer’s prediction of NVM life. A value of 100 indicates that the estimated endurance of the NVM in the NVM subsystem has been consumed, but may not indicate an NVM subsystem failure. The value is allowed to exceed 100.
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 26)]
       public byte[] Reserved0;
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
-      public byte[] DataUnitRead; // Data Units Read:  Contains the number of 512 byte data units the host has read from the controller; this value does not include metadata. This value is reported in thousands (i.e., a value of 1 corresponds to 1000 units of 512 bytes read)  and is rounded up.  When the LBA size is a value other than 512 bytes, the controller shall convert the amount of data read to 512 byte units. For the NVM command set, logical blocks read as part of Compare and Read operations shall be included in this value
+      public byte[] DataUnitRead; // Data Units Read:  Contains the number of 512 byte data units the host has read from the controller; this value does not include metadata. This value is reported in thousands (i.e., a value of 1 corresponds to 1000 units of 512 bytes read) and is rounded up.
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
-      public byte[] DataUnitWritten; // Data Units Written: Contains the number of 512 byte data units the host has written to the controller; this value does not include metadata. This value is reported in thousands (i.e., a value of 1 corresponds to 1000 units of 512 bytes written)  and is rounded up.  When the LBA size is a value other than 512 bytes, the controller shall convert the amount of data written to 512 byte units. For the NVM command set, logical blocks written as part of Write operations shall be included in this value. Write Uncorrectable commands shall not impact this value.
+      public byte[] DataUnitWritten; // Data Units Written:  Contains the number of 512 byte data units the host has written to the controller; this value does not include metadata. This value is reported in thousands (i.e., a value of 1 corresponds to 1000 units of 512 bytes written) and is rounded up.
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
-      public byte[] HostReadCommands; // Host Read Commands:  Contains the number of read commands  completed by  the controller. For the NVM command set, this is the number of Compare and Read commands.
-      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]      
-      public byte[] HostWrittenCommands; // Host Write Commands:  Contains the number of write commands  completed by  the controller. For the NVM command set, this is the number of Write commands.
+      public byte[] HostReadCommands; // Host Read Commands:  Contains the number of read commands completed by the controller. For the NVM command set, this is the number of Compare and Read commands.
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
-      public byte[] ControllerBusyTime; // Controller Busy Time:  Contains the amount of time the controller is busy with I/O commands. The controller is busy when there is a command outstanding to an I/O Queue (specifically, a command was issued via an I/O Submission Queue Tail doorbell write and the corresponding  completion queue entry  has not been posted yet to the associated I/O Completion Queue). This value is reported in minutes.
+      public byte[] HostWriteCommands; // Host Write Commands:  Contains the number of write commands completed by the controller. For the NVM command set, this is the number of Write commands.
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
-      public byte[] PowerCycle; // Power Cycles: Contains the number of power cycles.
+      public byte[] ControllerBusyTime; // Controller Busy Time:  Contains the amount of time the controller is busy with I/O commands.
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
-      public byte[] PowerOnHours; // Power On Hours: Contains the number of power-on hours. This does not include time that the controller was powered and in a low power state condition.
+      public byte[] PowerCycle; // Power Cycles:  Contains the number of power cycles.
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
-      public byte[] UnsafeShutdowns; // Unsafe Shutdowns: Contains the number of unsafe shutdowns. This count is incremented when a shutdown notification (CC.SHN) is not received prior to loss of power.
+      public byte[] PowerOnHours; // Power On Hours:  Contains the number of power-on hours. This does not include time that the controller was powered and in a low power state condition.
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+      public byte[] UnsafeShutdowns; // Unsafe Shutdowns:  Contains the number of unsafe shutdowns. This count is incremented when a shutdown notification is not received prior to loss of power.
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
       public byte[] MediaErrors; // Media Errors:  Contains the number of occurrences where the controller detected an unrecovered data integrity error. Errors such as uncorrectable ECC, CRC checksum failure, or LBA tag mismatch are included in this field.
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
       public byte[] ErrorInfoLogEntryCount; // Number of Error Information Log Entries:  Contains the number of Error Information log entries over the life of the controller
-      public uint WarningCompositeTemperatureTime; // Warning Composite Temperature Time: Contains the amount of time in minutes that the controller is operational and the Composite Temperature is greater than or equal to the Warning Composite Temperature Threshold (WCTEMP) field and less than the Critical Composite Temperature Threshold (CCTEMP) field in the Identify Controller data structure
-      public uint CriticalCompositeTemperatureTime; // Critical Composite Temperature Time: Contains the amount of time in minutes that the controller is operational and the Composite Temperature is greater the Critical Composite Temperature Threshold (CCTEMP) field in the Identify Controller data structure
+      public uint WarningCompositeTemperatureTime; // Warning Composite Temperature Time:  Contains the amount of time in minutes that the controller is operational and the Composite Temperature is greater than or equal to the Warning Composite Temperature Threshold.
+      public uint CriticalCompositeTemperatureTime; // Critical Composite Temperature Time:  Contains the amount of time in minutes that the controller is operational and the Composite Temperature is greater than the Critical Composite Temperature Threshold.
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 8)]
       public ushort[] TemperatureSensors; // Contains the current temperature reported by temperature sensor 1-8.
       [MarshalAs(UnmanagedType.ByValArray, SizeConst = 296)]
       public byte[] Reserved1;
     };
       
-    private class NVMeHealthInfoImpl : NVMeHealthInfo {      
+    private class NVMeHealthInfoImpl : NVMeHealthInfo {
       public NVMeHealthInfoImpl(NVMeHealthInfoLog log, byte[] rawData) {
         CriticalWarning = (NVMeCriticalWarning)log.CriticalWarning;
-        Temperature = KelvinToCelsius(log.Temperature);
+        Temperature = KelvinToCelsius(log.CompositeTemperature);
         AvailableSpare = log.AvailableSpare;
         AvailableSpareThreshold = log.AvailableSpareThreshold;
         PercentageUsed = log.PercentageUsed;
         DataUnitRead = BitConverter.ToUInt64(log.DataUnitRead, 0);
         DataUnitWritten = BitConverter.ToUInt64(log.DataUnitWritten, 0);
         HostReadCommands = BitConverter.ToUInt64(log.HostReadCommands, 0);
-        HostWrittenCommands = BitConverter.ToUInt64(log.HostWrittenCommands, 0);
+        HostWriteCommands = BitConverter.ToUInt64(log.HostWriteCommands, 0);
         ControllerBusyTime = BitConverter.ToUInt64(log.ControllerBusyTime, 0);
         PowerCycle = BitConverter.ToUInt64(log.PowerCycle, 0);
         PowerOnHours = BitConverter.ToUInt64(log.PowerOnHours, 0);
@@ -445,7 +445,7 @@ namespace OpenHardwareMonitor.Hardware.HDD {
         byte[] rawData;
         NVMeHealthInfoLog data = ReadPassThrough<NVMeHealthInfoLog>(NVMePassThroughOpcode.AdminGetLogPage, 0xffffffff, cdw10, out rawData);
         return new NVMeHealthInfoImpl(data, rawData);
-      } catch(Win32Exception) {        
+      } catch(Win32Exception) {
       }
       return null;
     }
@@ -479,7 +479,7 @@ namespace OpenHardwareMonitor.Hardware.HDD {
         Marshal.StructureToPtr(passThrough, buffer, false);
         
         uint bytesReturned = 0;
-        if (!NativeMethods.DeviceIoControl(handle, Command.IoctlScsiMiniPort, 
+        if (!NativeMethods.DeviceIoControl(handle, Command.IoctlScsiMiniPort,
             buffer, size, buffer, size, out bytesReturned, IntPtr.Zero))
           throw new Win32Exception();
         rawData = new byte[Marshal.SizeOf(typeof(T))];
@@ -502,24 +502,24 @@ namespace OpenHardwareMonitor.Hardware.HDD {
       if (disposing) {
         if (!handle.IsClosed)
           handle.Close();
-      }      
+      }
     }
     
     private static class NativeMethods {
       private const string KERNEL = "kernel32.dll";
 
-      [DllImport(KERNEL, CallingConvention = CallingConvention.Winapi, 
+      [DllImport(KERNEL, CallingConvention = CallingConvention.Winapi,
         CharSet = CharSet.Auto, SetLastError = true)]
       public static extern SafeFileHandle CreateFile(
        [MarshalAs(UnmanagedType.LPTStr)] string filename,
        [MarshalAs(UnmanagedType.U4)] FileAccess access,
        [MarshalAs(UnmanagedType.U4)] FileShare share,
-       IntPtr securityAttributes, 
+       IntPtr securityAttributes,
        [MarshalAs(UnmanagedType.U4)] FileMode creationDisposition,
        [MarshalAs(UnmanagedType.U4)] FileAttributes flagsAndAttributes,
        IntPtr templateFile);
 
-      [DllImport(KERNEL, CallingConvention = CallingConvention.Winapi, 
+      [DllImport(KERNEL, CallingConvention = CallingConvention.Winapi,
         CharSet = CharSet.Auto, SetLastError = true)]
       [return: MarshalAsAttribute(UnmanagedType.Bool)]
       public static extern bool DeviceIoControl(SafeHandle handle,

--- a/Hardware/HDD/WindowsNVMeSmart.cs
+++ b/Hardware/HDD/WindowsNVMeSmart.cs
@@ -1,0 +1,531 @@
+﻿/*
+ 
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ 
+  Copyright (C) 2017 Alexander Thulcke <alexth4ef9@gmail.com>
+  
+*/
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Win32.SafeHandles;
+
+namespace OpenHardwareMonitor.Hardware.HDD {
+
+  internal abstract class NVMeNamespaceInfo {
+    public ulong Size { get; protected set; }
+    public ulong Capacity { get; protected set; }
+    public ulong Utilization { get; protected set; }
+    public uint LBADataSize { get; protected set; }      
+    public byte[] RawData { get; protected set; }
+  }
+  
+  internal abstract class NVMeInfo {
+    public int Index { get; protected set; }
+    public ushort VID { get; protected set; }
+    public ushort SSVID { get; protected set; }
+    public string Serial { get; protected set; }
+    public string Model { get; protected set; }
+    public string Revision { get; protected set; }
+    public byte[] IEEE { get; protected set; }
+    public ulong TotalCapacity { get; protected set; }
+    public ulong UnallocatedCapacity { get; protected set; }
+    public ushort ControllerId { get; protected set; }
+    public uint NumberNamespaces { get; protected set; }
+    public NVMeNamespaceInfo Namespace1 { get; protected set; }
+    public byte[] RawData { get; protected set; }
+  }
+  
+  [Flags]
+  internal enum NVMeCriticalWarning {
+    None = 0x00,
+    AvailableSpaceLow = 0x01, // If set to 1, then the available spare space has fallen below the threshold.
+    TemperatureThreshold = 0x02, // If set to 1, then a temperature is above an over temperature threshold or below an under temperature threshold.
+    ReliabilityDegraded = 0x04, // If set to 1, then the device reliability has been degraded due to significant media related  errors or any internal error that degrades device reliability.
+    ReadOnly = 0x08, // If set to 1, then the media has been placed in read only mode
+    VolatileMemoryBackupDeviceFailed = 0x10, // If set to 1, then the volatile memory backup device has failed. This field is only valid if the controller has a volatile memory backup solution.
+  }
+
+  internal abstract class NVMeHealthInfo {    
+    public NVMeCriticalWarning CriticalWarning { get; protected set; }
+    public short Temperature { get; protected set; }
+    public byte AvailableSpare { get; protected set; }
+    public byte AvailableSpareThreshold { get; protected set; }
+    public byte PercentageUsed { get; protected set; }
+    public ulong DataUnitRead { get; protected set; }
+    public ulong DataUnitWritten { get; protected set; }
+    public ulong HostReadCommands { get; protected set; }
+    public ulong HostWrittenCommands { get; protected set; }
+    public ulong ControllerBusyTime { get; protected set; }
+    public ulong PowerCycle { get; protected set; }
+    public ulong PowerOnHours { get; protected set; }
+    public ulong UnsafeShutdowns { get; protected set; }
+    public ulong MediaErrors { get; protected set; }
+    public ulong ErrorInfoLogEntryCount { get; protected set; }
+    public uint WarningCompositeTemperatureTime { get; protected set; }
+    public uint CriticalCompositeTemperatureTime { get; protected set; }
+    public short[] TemperatureSensors { get; protected set; }
+    public byte[] RawData { get; protected set; }
+  }
+  
+  internal class WindowsNVMeSmart : IDisposable {
+    private enum Command : uint {
+      IoctlScsiMiniPort = 0x04d008,
+    }
+     
+    private const string NVMeMiniPortSignature = "NvmeMini";
+    private const uint NVMePassThroughSrbIoCode = 0xe0002000;
+
+    private enum NVMePassThroughOpcode : uint {
+      AdminGetLogPage = 0x02,
+      AdminIdentify = 0x06,
+    }
+    
+    [Flags]
+    private enum NVMePassThroughDirection : uint {
+      None = 0,
+      Out = 1,
+      In = 2,
+      InOut = In | Out,
+    }
+    
+    private enum NVMePassThroughQueue : uint {
+      AdminQ = 0,
+    }
+    
+    [StructLayout(LayoutKind.Sequential)]
+    private struct SrbIoControl {
+      public uint HeaderLenght;
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 8)]
+      public byte[] Signature;
+      public uint Timeout;
+      public uint ControlCode;
+      public uint ReturnCode;
+      public uint Length;
+    }
+    
+    [StructLayout(LayoutKind.Sequential)]
+    private struct NVMePassThrough {
+      #region SRB_IO_CONTROL
+      public uint HeaderLenght;
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 8)]
+      public byte[] Signature;
+      public uint Timeout;
+      public uint ControlCode;
+      public uint ReturnCode;
+      public uint Length;
+      #endregion
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 6)]
+      public uint[] VendorSpecific;
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+      public uint[] NVMeCmd;
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
+      public uint[] CplEntry;
+      public NVMePassThroughDirection Direction;
+      public NVMePassThroughQueue Queue;
+      public uint DataBufferLen;
+      public uint MetaDataLen;
+      public uint ReturnBufferLen;
+      //[MarshalAs(UnmanagedType.ByValArray, SizeConst = 1)]
+      //public byte[] DataBuffer;
+    }
+    
+    [StructLayout(LayoutKind.Sequential)]
+    private struct NVMePowerStateDesc {
+      public ushort mp; // bit 0:15.    Maximum  Power (MP) in centiwatts
+      public byte Reserved0; // bit 16:23
+      public byte mps_nops; // bit 24: Max Power Scale (MPS), bit 25: Non-Operational State (NOPS)
+      public uint enlat; // bit 32:63.   Entry Latency (ENLAT) in microseconds
+      public uint exlat; // bit 64:95.   Exit Latency (EXLAT) in microseconds
+      public byte rrt; // bit 96:100.  Relative Read Throughput (RRT)
+      public byte rrl; // bit 104:108  Relative Read Latency (RRL)
+      public byte rwt; // bit 112:116  Relative Write Throughput (RWT)
+      public byte rwl; // bit 120:124  Relative Write Latency (RWL)
+      public ushort idlp; // bit 128:143  Idle Power (IDLP)
+      public byte ips; // bit 150:151  Idle Power Scale (IPS)
+      public byte Reserved7; // bit 152:159
+      public ushort actp; // bit 160:175  Active Power (ACTP)
+      public byte apw_aps; // bit 176:178  Active Power Workload (APW), bit 182:183  Active Power Scale (APS)
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 9)]
+      public byte[] Reserved9;       // bit 184:255.
+    }
+    
+    [StructLayout(LayoutKind.Sequential)]
+    private struct NVMeIdentifyControllerData {
+      public ushort vid; // byte 0:1.    M - PCI Vendor ID (VID)
+      public ushort ssvid; // byte 2:3.    M - PCI Subsystem Vendor ID (SSVID)
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 20)]
+      public byte[] sn; // byte 4: 23.  M - Serial Number (SN)
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 40)]
+      public byte[] mn; // byte 24:63.  M - Model Number (MN)
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 8)]
+      public byte[] fr; // byte 64:71.  M - Firmware Revision (FR)
+      public byte rab; // byte 72.     M - Recommended Arbitration Burst (RAB)
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 3)]
+      public byte[] ieee; // byte 73:75.  M - IEEE OUI Identifier (IEEE). Controller Vendor code.
+      public byte cmic; // byte 76.     O - Controller Multi-Path I/O and Namespace Sharing Capabilities (CMIC)
+      public byte mdts; // byte 77.     M - Maximum Data Transfer Size (MDTS)
+      public ushort cntlid; // byte 78:79.   M - Controller ID (CNTLID)
+      public uint ver; // byte 80:83.   M - Version (VER)
+      public uint rtd3r; // byte 84:87.   M - RTD3 Resume Latency (RTD3R)
+      public uint rtd3e; // byte 88:91.   M - RTD3 Entry Latency (RTD3E)
+      public uint oaes; // byte 92:95.   M - Optional Asynchronous Events Supported (OAES)
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 144)]
+      public byte[] Reserved0; // byte 96:239.
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+      public byte[] ReservedForManagement; // byte 240:255.  Refer to the NVMe Management Interface Specification for definition.
+      public ushort oacs; // byte 256:257. M - Optional Admin Command Support (OACS)
+      public byte acl; // byte 258.    M - Abort Command Limit (ACL)
+      public byte aerl; // byte 259.    M - Asynchronous Event Request Limit (AERL)
+      public byte frmw; // byte 260.    M - Firmware Updates (FRMW)
+      public byte lpa; // byte 261.    M - Log Page Attributes (LPA)
+      public byte elpe; // byte 262.    M - Error Log Page Entries (ELPE)
+      public byte npss; // byte 263.    M - Number of Power States Support (NPSS)
+      public byte avscc; // byte 264.    M - Admin Vendor Specific Command Configuration (AVSCC)
+      public byte apsta; // byte 265.     O - Autonomous Power State Transition Attributes (APSTA)
+      public ushort wctemp; // byte 266:267. M - Warning Composite Temperature Threshold (WCTEMP)
+      public ushort cctemp; // byte 268:269. M - Critical Composite Temperature Threshold (CCTEMP)
+      public ushort mtfa; // byte 270:271. O - Maximum Time for Firmware Activation (MTFA)
+      public uint hmpre; // byte 272:275. O - Host Memory Buffer Preferred Size (HMPRE)
+      public uint hmmin; // byte 276:279. O - Host Memory Buffer Minimum Size (HMMIN)
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+      public byte[] tnvmcap; // byte 280:295. O - Total NVM Capacity (TNVMCAP)
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+      public byte[] unvmcap; // byte 296:311. O - Unallocated NVM Capacity (UNVMCAP)
+      public uint rpmbs; // byte 312:315. O - Replay Protected Memory Block Support (RPMBS)
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 196)]
+      public byte[] Reserved1; // byte 316:511.
+      public byte sqes; // byte 512.    M - Submission Queue Entry Size (SQES)
+      public byte cqes; // byte 513.    M - Completion Queue Entry Size (CQES)
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 2)]
+      public byte[] Reserved2; // byte 514:515.
+      public uint nn; // byte 516:519. M - Number of Namespaces (NN)
+      public ushort oncs; // byte 520:521. M - Optional NVM Command Support (ONCS)
+      public ushort fuses; // byte 522:523. M - Fused Operation Support (FUSES)
+      public byte fna; // byte 524.     M - Format NVM Attributes (FNA)
+      public byte vwc; // byte 525.     M - Volatile Write Cache (VWC)
+      public ushort awun; // byte 526:527. M - Atomic Write Unit Normal (AWUN)
+      public ushort awupf; // byte 528:529. M - Atomic Write Unit Power Fail (AWUPF)
+      public byte nvscc; // byte 530.     M - NVM Vendor Specific Command Configuration (NVSCC)
+      public byte Reserved3; // byte 531.
+      public ushort acwu; // byte 532:533  O - Atomic Compare & Write Unit (ACWU)
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 2)]
+      public byte[] Reserved4; // byte 534:535.
+      public uint sgls; // byte 536:539. O - SGL Support (SGLS)
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 164)]
+      public byte[] Reserved5; // byte 540:703.
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 1344)]    
+      public byte[] Reserved6; // byte 704:2047.
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
+      public NVMePowerStateDesc[] pds; // byte 2048 : 3071, Power State Descriptors
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 1024)]
+      public byte[] vs; // byte 3072 : 4095, Vendor Specific
+    }
+        
+    [StructLayout(LayoutKind.Sequential)]
+    private struct NVMeLBAFormat {
+      public ushort ms; // bit 0:15     Metadata Size (MS)
+      public byte lbads; // bit 16:23    LBA  Data  Size (LBADS)
+      public byte rp; // bit 24:25    Relative Performance (RP)
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct NVMeIdentifyNamespaceData {
+      public ulong nsze; // byte 0:7.    M - Namespace Size (NSZE)
+      public ulong ncap; // byte 8:15    M - Namespace Capacity (NCAP)
+      public ulong nuse; // byte 16:23   M - Namespace Utilization (NUSE)
+      public byte nsfeat; // byte 24      M - Namespace Features (NSFEAT)
+      public byte nlbaf; // byte 25      M - Number of LBA Formats (NLBAF)
+      public byte flbas; // byte 26      M - Formatted LBA Size (FLBAS)
+      public byte mc; // byte 27      M - Metadata Capabilities (MC)
+      public byte dpc; // byte 28      M - End-to-end Data Protection Capabilities (DPC)
+      public byte dps; // byte 29      M - End-to-end Data Protection Type Settings (DPS)
+      public byte nmic; // byte 30      O - Namespace Multi-path I/O and Namespace Sharing Capabilities (NMIC)
+      public byte rescap; // byte 31      O - Reservation Capabilities (RESCAP)
+      public byte fpi; // byte 32      O - Format Progress Indicator (FPI)
+      public byte Reserved0; // byte 33
+      public ushort nawun; // byte 34:35 O - Namespace Atomic Write Unit Normal (NAWUN)
+      public ushort nawupf;// byte 36:37 O - Namespace Atomic Write Unit Power Fail (NAWUPF)
+      public ushort nacwu; // byte 38:39 O - Namespace Atomic Compare & Write Unit (NACWU)
+      public ushort nabsn; // byte 40:41 O - Namespace Atomic Boundary Size Normal (NABSN)
+      public ushort nabo; // byte 42:43 O - Namespace Atomic Boundary Offset (NABO)
+      public ushort nabspf; // byte 44:45 O - Namespace Atomic Boundary Size Power Fail (NABSPF)
+      public ushort Reserved1; // byte 46:47
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]      
+      public byte[] nvmcap; // byte 48:63 O - NVM Capacity (NVMCAP)
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 40)]      
+      public byte[] Reserved2; // byte 64:103
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]      
+      public byte[] nguid; // byte 104:119 O - NAmespace Globally Unique Identifier (NGUID)
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 8)]
+      public byte[] eui64; // byte 120:127 M - IEEE Extended Unique Identifier (EUI64)
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+      public NVMeLBAFormat[] lbaf; // byte 128:131 M - LBA Format 0 Support (LBAF0), byte 132:191 O - LBA Format 1-15 Support (LBAF1-LBAF15)
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 192)]
+      public byte[] Reserved3;     // byte 192:383
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 3712)]
+      public byte[] vs; // byte 384:4095 O - Vendor Specific (VS): This range of bytes is allocated for vendor specific usage.      
+    }
+    
+    private class NVMeNamespaceInfoImpl : NVMeNamespaceInfo {
+      public NVMeNamespaceInfoImpl(NVMeIdentifyNamespaceData data, byte[] rawData) {
+        byte shift = data.lbaf[data.flbas & 0x0f].lbads;
+        Size = ShiftValue(data.nsze, shift);
+        Capacity = ShiftValue(data.ncap, shift);
+        Utilization = ShiftValue(data.nuse, shift);
+        LBADataSize = 1u << shift;
+        RawData = rawData;
+      }
+    }
+    
+    private class NVMeInfoImpl : NVMeInfo {
+      public NVMeInfoImpl(int index, NVMeIdentifyControllerData data, byte[] rawData) {
+        Index = index;
+        VID = data.vid;
+        SSVID = data.ssvid;
+        Serial = GetString(data.sn);
+        Model = GetString(data.mn);
+        Revision = GetString(data.fr);
+        IEEE = data.ieee;        
+        TotalCapacity = BitConverter.ToUInt64(data.tnvmcap, 0); // 128bit little endian
+        UnallocatedCapacity = BitConverter.ToUInt64(data.unvmcap, 0);
+        ControllerId = data.cntlid;
+        NumberNamespaces = data.nn;
+        RawData = rawData;
+      }      
+    
+      public NVMeInfoImpl(int index, NVMeIdentifyControllerData data, byte[] rawData,
+        NVMeIdentifyNamespaceData namespaceData, byte[] namespaceRawData)
+        : this(index, data, rawData) 
+      {
+        Namespace1 = new NVMeNamespaceInfoImpl(namespaceData, namespaceRawData);
+      }
+    }
+    
+    [StructLayout(LayoutKind.Sequential)]
+    private struct NVMeHealthInfoLog {
+      public byte CriticalWarning; // This field indicates critical warnings for the state of the  controller. Each bit corresponds to a critical warning type; multiple bits may be set.
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 2)]
+      public byte[] Temperature; // Temperature: Contains the temperature of the overall device (controller and NVM included) in units of Kelvin. If the temperature exceeds the temperature threshold, refer to section 5.12.1.4, then an asynchronous event completion may occur
+      public byte AvailableSpare; // Available Spare:  Contains a normalized percentage (0 to 100%) of the remaining spare capacity available
+      public byte AvailableSpareThreshold; // Available Spare Threshold:  When the Available Spare falls below the threshold indicated in this field, an asynchronous event  completion may occur. The value is indicated as a normalized percentage (0 to 100%).
+      public byte PercentageUsed; // Percentage Used
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 26)]
+      public byte[] Reserved0;
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+      public byte[] DataUnitRead; // Data Units Read:  Contains the number of 512 byte data units the host has read from the controller; this value does not include metadata. This value is reported in thousands (i.e., a value of 1 corresponds to 1000 units of 512 bytes read)  and is rounded up.  When the LBA size is a value other than 512 bytes, the controller shall convert the amount of data read to 512 byte units. For the NVM command set, logical blocks read as part of Compare and Read operations shall be included in this value
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+      public byte[] DataUnitWritten; // Data Units Written: Contains the number of 512 byte data units the host has written to the controller; this value does not include metadata. This value is reported in thousands (i.e., a value of 1 corresponds to 1000 units of 512 bytes written)  and is rounded up.  When the LBA size is a value other than 512 bytes, the controller shall convert the amount of data written to 512 byte units. For the NVM command set, logical blocks written as part of Write operations shall be included in this value. Write Uncorrectable commands shall not impact this value.
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+      public byte[] HostReadCommands; // Host Read Commands:  Contains the number of read commands  completed by  the controller. For the NVM command set, this is the number of Compare and Read commands.
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]      
+      public byte[] HostWrittenCommands; // Host Write Commands:  Contains the number of write commands  completed by  the controller. For the NVM command set, this is the number of Write commands.
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+      public byte[] ControllerBusyTime; // Controller Busy Time:  Contains the amount of time the controller is busy with I/O commands. The controller is busy when there is a command outstanding to an I/O Queue (specifically, a command was issued via an I/O Submission Queue Tail doorbell write and the corresponding  completion queue entry  has not been posted yet to the associated I/O Completion Queue). This value is reported in minutes.
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+      public byte[] PowerCycle; // Power Cycles: Contains the number of power cycles.
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+      public byte[] PowerOnHours; // Power On Hours: Contains the number of power-on hours. This does not include time that the controller was powered and in a low power state condition.
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+      public byte[] UnsafeShutdowns; // Unsafe Shutdowns: Contains the number of unsafe shutdowns. This count is incremented when a shutdown notification (CC.SHN) is not received prior to loss of power.
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+      public byte[] MediaErrors; // Media Errors:  Contains the number of occurrences where the controller detected an unrecovered data integrity error. Errors such as uncorrectable ECC, CRC checksum failure, or LBA tag mismatch are included in this field.
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+      public byte[] ErrorInfoLogEntryCount; // Number of Error Information Log Entries:  Contains the number of Error Information log entries over the life of the controller
+      public uint WarningCompositeTemperatureTime; // Warning Composite Temperature Time: Contains the amount of time in minutes that the controller is operational and the Composite Temperature is greater than or equal to the Warning Composite Temperature Threshold (WCTEMP) field and less than the Critical Composite Temperature Threshold (CCTEMP) field in the Identify Controller data structure
+      public uint CriticalCompositeTemperatureTime; // Critical Composite Temperature Time: Contains the amount of time in minutes that the controller is operational and the Composite Temperature is greater the Critical Composite Temperature Threshold (CCTEMP) field in the Identify Controller data structure
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 8)]
+      public ushort[] TemperatureSensors; // Contains the current temperature reported by temperature sensor 1-8.
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 296)]
+      public byte[] Reserved1;
+    };
+      
+    private class NVMeHealthInfoImpl : NVMeHealthInfo {      
+      public NVMeHealthInfoImpl(NVMeHealthInfoLog log, byte[] rawData) {
+        CriticalWarning = (NVMeCriticalWarning)log.CriticalWarning;
+        Temperature = KelvinToCelsius(log.Temperature);
+        AvailableSpare = log.AvailableSpare;
+        AvailableSpareThreshold = log.AvailableSpareThreshold;
+        PercentageUsed = log.PercentageUsed;
+        DataUnitRead = BitConverter.ToUInt64(log.DataUnitRead, 0);
+        DataUnitWritten = BitConverter.ToUInt64(log.DataUnitWritten, 0);
+        HostReadCommands = BitConverter.ToUInt64(log.HostReadCommands, 0);
+        HostWrittenCommands = BitConverter.ToUInt64(log.HostWrittenCommands, 0);
+        ControllerBusyTime = BitConverter.ToUInt64(log.ControllerBusyTime, 0);
+        PowerCycle = BitConverter.ToUInt64(log.PowerCycle, 0);
+        PowerOnHours = BitConverter.ToUInt64(log.PowerOnHours, 0);
+        UnsafeShutdowns = BitConverter.ToUInt64(log.UnsafeShutdowns, 0);
+        MediaErrors = BitConverter.ToUInt64(log.MediaErrors, 0);
+        ErrorInfoLogEntryCount = BitConverter.ToUInt64(log.ErrorInfoLogEntryCount, 0);
+        WarningCompositeTemperatureTime = log.WarningCompositeTemperatureTime;
+        CriticalCompositeTemperatureTime = log.CriticalCompositeTemperatureTime;
+        TemperatureSensors = new short[log.TemperatureSensors.Length];
+        for(int i=0; i<TemperatureSensors.Length; i++)
+          TemperatureSensors[i] = KelvinToCelsius(log.TemperatureSensors[i]);
+        RawData = rawData;
+      }
+    }
+    
+    private static string GetString(byte[] s) {
+      return Encoding.ASCII.GetString(s).Trim('\t', '\n', '\r', ' ', '\0');
+    }
+    
+    // should use BitInteger from .NET 4.0, 128-bit integers
+    private static ulong ShiftValue(ulong v, byte s) {
+      ulong low = v << s;
+      //ulong high = v >> (64 - s);
+      return low;
+    }
+    
+    private static short KelvinToCelsius(ushort k) {
+      return (short)((k > 0) ? (int)k - 273 : short.MinValue);
+    }
+
+    private static short KelvinToCelsius(byte[] k) {
+      return KelvinToCelsius(BitConverter.ToUInt16(k, 0));
+    }
+             
+    private readonly SafeHandle handle;
+    private int driveNumber;
+    
+#if DEBUG
+    static WindowsNVMeSmart() {
+      Debug.Assert(Marshal.SizeOf(typeof(NVMeIdentifyControllerData)) == 4096);
+      Debug.Assert(Marshal.SizeOf(typeof(NVMeLBAFormat)) == 4);
+      Debug.Assert(Marshal.SizeOf(typeof(NVMeIdentifyNamespaceData)) == 4096);
+      Debug.Assert(Marshal.SizeOf(typeof(NVMeHealthInfoLog)) == 512);
+    }
+#endif
+    
+    public WindowsNVMeSmart(int driveNumber) {
+      this.driveNumber = driveNumber;
+      handle = NativeMethods.CreateFile(string.Format(@"\\.\Scsi{0}:", driveNumber), FileAccess.ReadWrite,
+        FileShare.ReadWrite, IntPtr.Zero, FileMode.Open, FileAttributes.Normal, IntPtr.Zero);
+    }
+
+    public bool IsValid {
+      get { return !handle.IsInvalid; }
+    }
+    
+    public void Close() {
+      Dispose(true);
+      GC.SuppressFinalize(this);
+    }
+    
+    public NVMeInfo GetInfo() {
+      if (handle.IsClosed)
+        throw new ObjectDisposedException("WindowsNVMeSmart");
+      try {
+        byte[] rawData;
+        NVMeIdentifyControllerData data = ReadPassThrough<NVMeIdentifyControllerData>(NVMePassThroughOpcode.AdminIdentify, 0x00000000, 0x000000001, out rawData);
+        if (data.nn == 1) {
+          byte[] rawDataNamespace;
+          NVMeIdentifyNamespaceData nspace = ReadPassThrough<NVMeIdentifyNamespaceData>(NVMePassThroughOpcode.AdminIdentify, 0x000000001, 0x00000000, out rawDataNamespace);
+          return new NVMeInfoImpl(driveNumber, data, rawData, nspace, rawDataNamespace);
+        }
+        return new NVMeInfoImpl(driveNumber, data, rawData);
+      } catch(Win32Exception e) {
+        Console.WriteLine(e);
+      }
+      return null;
+    }
+    
+    public NVMeHealthInfo GetHealthInfo() {
+      if (handle.IsClosed)
+        throw new ObjectDisposedException("WindowsNVMeSmart");
+      try {
+        uint size = (uint)Marshal.SizeOf(typeof(NVMeHealthInfoLog));
+        uint cdw10 = 0x000000002 | (((size / 4) - 1) << 16);
+        byte[] rawData;
+        NVMeHealthInfoLog data = ReadPassThrough<NVMeHealthInfoLog>(NVMePassThroughOpcode.AdminGetLogPage, 0xffffffff, cdw10, out rawData);
+        return new NVMeHealthInfoImpl(data, rawData);
+      } catch(Win32Exception) {        
+      }
+      return null;
+    }
+    
+    private T ReadPassThrough<T>(NVMePassThroughOpcode opcode, uint nsid, uint cdw10, out byte[] rawData) {
+      NVMePassThroughDirection direction = (NVMePassThroughDirection)((uint)opcode & 0x00000003);
+      if ((direction & NVMePassThroughDirection.Out) != 0)
+          throw new ArgumentOutOfRangeException("opcode");
+            
+      int size = Marshal.SizeOf(typeof(NVMePassThrough)) + Marshal.SizeOf(typeof(T));
+      NVMePassThrough passThrough = new NVMePassThrough();
+      passThrough.HeaderLenght = (uint)Marshal.SizeOf(typeof(SrbIoControl));
+      passThrough.Signature = Encoding.ASCII.GetBytes(NVMeMiniPortSignature);
+      passThrough.Timeout = 60;
+      passThrough.ControlCode = NVMePassThroughSrbIoCode;
+      passThrough.ReturnCode = 0;
+      passThrough.Length = (uint)(size - Marshal.SizeOf(typeof(SrbIoControl)));
+      
+      passThrough.NVMeCmd = new uint[16];
+      passThrough.NVMeCmd[0] = (uint)opcode;
+      passThrough.NVMeCmd[1] = nsid;
+      passThrough.NVMeCmd[10] = cdw10;
+      passThrough.Direction = direction;
+      passThrough.Queue = NVMePassThroughQueue.AdminQ;
+      passThrough.DataBufferLen = 0;
+      passThrough.MetaDataLen = 0;
+      passThrough.ReturnBufferLen = (uint)size;
+      
+      IntPtr buffer = Marshal.AllocHGlobal(size);
+      try {
+        Marshal.StructureToPtr(passThrough, buffer, false);
+        
+        uint bytesReturned = 0;
+        if (!NativeMethods.DeviceIoControl(handle, Command.IoctlScsiMiniPort, 
+            buffer, size, buffer, size, out bytesReturned, IntPtr.Zero))
+          throw new Win32Exception();
+        rawData = new byte[Marshal.SizeOf(typeof(T))];
+        IntPtr dataBuffer = new IntPtr(buffer.ToInt64() + Marshal.SizeOf(typeof(NVMePassThrough)));
+        Marshal.Copy(dataBuffer, rawData, 0, rawData.Length);
+        return (T)Marshal.PtrToStructure(dataBuffer, typeof(T));
+      }
+      finally {
+        Marshal.FreeHGlobal(buffer);
+      }
+    }
+          
+    #region IDisposable implementation
+    public void Dispose() {
+      Close();
+    }
+    #endregion
+    
+    protected void Dispose(bool disposing) {
+      if (disposing) {
+        if (!handle.IsClosed)
+          handle.Close();
+      }      
+    }
+    
+    private static class NativeMethods {
+      private const string KERNEL = "kernel32.dll";
+
+      [DllImport(KERNEL, CallingConvention = CallingConvention.Winapi, 
+        CharSet = CharSet.Auto, SetLastError = true)]
+      public static extern SafeFileHandle CreateFile(
+       [MarshalAs(UnmanagedType.LPTStr)] string filename,
+       [MarshalAs(UnmanagedType.U4)] FileAccess access,
+       [MarshalAs(UnmanagedType.U4)] FileShare share,
+       IntPtr securityAttributes, 
+       [MarshalAs(UnmanagedType.U4)] FileMode creationDisposition,
+       [MarshalAs(UnmanagedType.U4)] FileAttributes flagsAndAttributes,
+       IntPtr templateFile);
+
+      [DllImport(KERNEL, CallingConvention = CallingConvention.Winapi, 
+        CharSet = CharSet.Auto, SetLastError = true)]
+      [return: MarshalAsAttribute(UnmanagedType.Bool)]
+      public static extern bool DeviceIoControl(SafeHandle handle,
+        Command command, IntPtr dataIn, int dataInSize,
+        IntPtr dataOut, int dataOutSize, out uint bytesReturned,
+        IntPtr overlapped);
+    }
+  }
+}

--- a/Hardware/HDD/WindowsStorage.cs
+++ b/Hardware/HDD/WindowsStorage.cs
@@ -1,0 +1,241 @@
+﻿/*
+ 
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ 
+  Copyright (C) 2009-2015 Michael Möller <mmoeller@openhardwaremonitor.org>
+  Copyright (C) 2010 Paul Werelds
+  Copyright (C) 2011 Roland Reinl <roland-reinl@gmx.de>
+  Copyright (C) 2017 Alexander Thulcke <alexth4ef9@gmail.com>
+  
+*/
+ 
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Management;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace OpenHardwareMonitor.Hardware.HDD {
+  internal enum StorageBusType {
+    BusTypeUnknown = 0x00,
+    BusTypeScsi,
+    BusTypeAtapi,
+    BusTypeAta,
+    BusType1394,
+    BusTypeSsa,
+    BusTypeFibre,
+    BusTypeUsb,
+    BusTypeRAID,
+    BusTypeiScsi,
+    BusTypeSas,
+    BusTypeSata,
+    BusTypeSd,
+    BusTypeMmc,
+    BusTypeVirtual,
+    BusTypeFileBackedVirtual,
+    BusTypeSpaces,
+    BusTypeNvme,
+    BusTypeSCM,
+    BusTypeMax,
+    BusTypeMaxReserved = 0x7F,
+  }
+  
+  internal abstract class StorageInfo {
+    public int Index { get; protected set; }
+    public string Vendor { get; protected set; }
+    public string Product { get; protected set; }
+    public string Revision { get; protected set; }
+    public string Serial { get; protected set; }
+    public StorageBusType BusType { get; protected set; }
+    public bool Removable { get; protected set; }
+    public string Name { 
+      get { return (Vendor + " " + Product).Trim(); }
+    }
+    public byte[] RawData { get; protected set; }
+  }
+  
+  internal static class WindowsStorage {    
+    private enum StorageCommand : uint {
+      QueryProperty = 0x002d1400,
+    }
+        
+    private enum StorageQueryType {
+      PropertyStandardQuery = 0,
+      PropertyExistsQuery,
+      PropertyMaskQuery,
+      PropertyQueryMaxDefined,      
+    }
+    
+    private enum StoragePropertyId {
+      StorageDeviceProperty = 0,
+      StorageAdapterProperty,
+      StorageDeviceIdProperty,
+      StorageDeviceUniqueIdProperty,
+      StorageDeviceWriteCacheProperty,
+      StorageMiniportProperty,
+      StorageAccessAlignmentProperty,
+      StorageDeviceSeekPenaltyProperty,
+      StorageDeviceTrimProperty,
+      StorageDeviceWriteAggregationProperty,
+      StorageDeviceDeviceTelemetryProperty,
+      StorageDeviceLBProvisioningProperty,
+      StorageDevicePowerProperty,
+      StorageDeviceCopyOffloadProperty,
+      StorageDeviceResiliencyProperty,
+      StorageDeviceMediumProductType,
+      StorageAdapterRpmbProperty,
+      StorageDeviceIoCapabilityProperty = 48,
+      StorageAdapterProtocolSpecificProperty,
+      StorageDeviceProtocolSpecificProperty,
+      StorageAdapterTemperatureProperty,
+      StorageDeviceTemperatureProperty,
+      StorageAdapterPhysicalTopologyProperty,
+      StorageDevicePhysicalTopologyProperty,
+      StorageDeviceAttributesProperty,
+      StorageDeviceManagementStatus,
+      StorageAdapterSerialNumberProperty,
+      StorageDeviceLocationProperty,
+    }
+    
+    [StructLayout(LayoutKind.Sequential)]
+    private struct StoragePropertyQuery {
+      public StoragePropertyId PropertyId;
+      public StorageQueryType QueryType;
+      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 0x1)]
+      public byte[] AdditionalParameters;
+    }
+    
+    [StructLayout(LayoutKind.Sequential)]
+    private struct StorageDescriptorHeader {
+      public uint Version;
+      public uint Size;
+    }
+        
+    [StructLayout(LayoutKind.Sequential)]
+    private struct StorageDeviceDescriptor {
+      public uint Version;
+      public uint Size;
+      public byte DeviceType;
+      public byte DeviceTypeModifier;
+      [MarshalAs(UnmanagedType.U1)]
+      public bool RemovableMedia;
+      [MarshalAs(UnmanagedType.U1)]
+      public bool CommandQueueing;
+      public uint VendorIdOffset;
+      public uint ProductIdOffset;
+      public uint ProductRevisionOffset;
+      public uint SerialNumberOffset;
+      public StorageBusType BusType;
+      public uint RawPropertiesLength;
+      //[MarshalAs(UnmanagedType.ByValArray, SizeConst = 0x1)]
+      //public byte[] RawDeviceProperties;
+    } 
+        
+    private class StorageInfoImpl : StorageInfo {    
+      public StorageInfoImpl(int index, IntPtr descriptorPtr) {
+        StorageDeviceDescriptor descriptor = (StorageDeviceDescriptor)Marshal.PtrToStructure(descriptorPtr, typeof(StorageDeviceDescriptor));
+        Index = index;
+        Vendor = GetString(descriptorPtr, descriptor.VendorIdOffset);
+        Product = GetString(descriptorPtr, descriptor.ProductIdOffset);
+        Revision = GetString(descriptorPtr, descriptor.ProductRevisionOffset);
+        Serial = GetString(descriptorPtr, descriptor.SerialNumberOffset);
+        BusType = descriptor.BusType;
+        Removable = descriptor.RemovableMedia;
+        RawData = new byte[descriptor.Size];
+        Marshal.Copy(descriptorPtr, RawData, 0, RawData.Length);
+      }
+
+      private static string GetString(IntPtr descriptorPtr, uint offset) {
+        return (offset > 0) ? Marshal.PtrToStringAnsi(new IntPtr(descriptorPtr.ToInt64() + offset)).Trim() : string.Empty;
+      }      
+    }
+        
+    public static StorageInfo GetStorageInfo(int driveNumber) {      
+      using(SafeHandle handle = NativeMethods.CreateFile(@"\\.\PhysicalDrive" + driveNumber,
+        0, FileShare.ReadWrite, IntPtr.Zero, FileMode.Open, FileAttributes.Normal, IntPtr.Zero))
+      {      
+        if (handle.IsInvalid)
+          return null;
+        
+        StoragePropertyQuery query = new StoragePropertyQuery();
+        StorageDescriptorHeader header;
+        uint bytesReturned = 0;
+  
+        query.PropertyId = StoragePropertyId.StorageDeviceProperty;
+        query.QueryType = StorageQueryType.PropertyStandardQuery;
+        
+        if (!NativeMethods.DeviceIoControl(handle, StorageCommand.QueryProperty, ref query, 
+            Marshal.SizeOf(query), out header, Marshal.SizeOf(typeof(StorageDescriptorHeader)),
+            out bytesReturned, IntPtr.Zero))
+          return null;
+          
+        IntPtr descriptorPtr = Marshal.AllocHGlobal((int)header.Size);
+        try {        
+          if (!NativeMethods.DeviceIoControl(handle, StorageCommand.QueryProperty, ref query, 
+              Marshal.SizeOf(query), descriptorPtr, header.Size, 
+              out bytesReturned, IntPtr.Zero))
+            return null;
+          
+          return new StorageInfoImpl(driveNumber, descriptorPtr);
+        }
+        finally {
+          Marshal.FreeHGlobal(descriptorPtr);
+        }
+      }
+    }
+    
+    public static string[] GetLogicalDrives(int driveIndex) {
+      List<string> list = new List<string>();
+      try {
+        using (ManagementObjectSearcher s = new ManagementObjectSearcher(
+            "root\\CIMV2",
+            "SELECT * FROM Win32_DiskPartition " +
+            "WHERE DiskIndex = " + driveIndex))
+        using (ManagementObjectCollection dpc = s.Get())
+        foreach (ManagementObject dp in dpc) 
+          using (ManagementObjectCollection ldc = 
+            dp.GetRelated("Win32_LogicalDisk"))
+          foreach (ManagementBaseObject ld in ldc) 
+            list.Add(((string)ld["Name"]).TrimEnd(':')); 
+      } catch { }
+      return list.ToArray();
+    }
+    
+    private static class NativeMethods {
+      private const string KERNEL = "kernel32.dll";
+
+      [DllImport(KERNEL, CallingConvention = CallingConvention.Winapi, 
+        CharSet = CharSet.Auto, SetLastError = true)]
+      public static extern SafeFileHandle CreateFile(
+       [MarshalAs(UnmanagedType.LPTStr)] string filename,
+       [MarshalAs(UnmanagedType.U4)] FileAccess access,
+       [MarshalAs(UnmanagedType.U4)] FileShare share,
+       IntPtr securityAttributes, 
+       [MarshalAs(UnmanagedType.U4)] FileMode creationDisposition,
+       [MarshalAs(UnmanagedType.U4)] FileAttributes flagsAndAttributes,
+       IntPtr templateFile);
+
+      [DllImport(KERNEL, CallingConvention = CallingConvention.Winapi, 
+        CharSet = CharSet.Auto, SetLastError = true)]
+      [return: MarshalAs(UnmanagedType.Bool)]
+      public static extern bool DeviceIoControl(
+          SafeHandle handle, StorageCommand command,
+          ref StoragePropertyQuery query, int querySize,
+          out StorageDescriptorHeader descriptorHeader,
+          int descriptorHeaderSize,
+          out uint bytesReturned, IntPtr overlapped);      
+
+      [DllImport(KERNEL, CallingConvention = CallingConvention.Winapi, 
+        CharSet = CharSet.Auto, SetLastError = true)]
+      [return: MarshalAs(UnmanagedType.Bool)]
+      public static extern bool DeviceIoControl(
+          SafeHandle handle, StorageCommand command,
+          ref StoragePropertyQuery query, int querySize,
+          IntPtr descriptor, uint descriptorSize,
+          out uint bytesReturned, IntPtr overlapped);      
+    }    
+  }
+}

--- a/OpenHardwareMonitorLib.csproj
+++ b/OpenHardwareMonitorLib.csproj
@@ -63,11 +63,13 @@
     <Compile Include="Hardware\ATI\ATIGroup.cs" />
     <Compile Include="Hardware\Control.cs" />
     <Compile Include="Hardware\FirmwareTable.cs" />
+    <Compile Include="Hardware\HDD\AbstractStorage.cs" />
     <Compile Include="Hardware\HDD\DebugSmart.cs" />
     <Compile Include="Hardware\HDD\DriveAttributeValue.cs" />
     <Compile Include="Hardware\HDD\DriveThresholdValue.cs" />
     <Compile Include="Hardware\HDD\HDDGeneric.cs" />
     <Compile Include="Hardware\HDD\ISmart.cs" />
+    <Compile Include="Hardware\HDD\NVMeGeneric.cs" />
     <Compile Include="Hardware\HDD\SmartAttribute.cs" />
     <Compile Include="Hardware\HDD\SmartNames.cs" />
     <Compile Include="Hardware\HDD\RequireSmartAttribute.cs" />
@@ -78,6 +80,9 @@
     <Compile Include="Hardware\HDD\SSDPlextor.cs" />
     <Compile Include="Hardware\HDD\SSDSamsung.cs" />
     <Compile Include="Hardware\HDD\SSDSandforce.cs" />
+    <Compile Include="Hardware\HDD\StorageGeneric.cs" />
+    <Compile Include="Hardware\HDD\WindowsNVMeSmart.cs" />
+    <Compile Include="Hardware\HDD\WindowsStorage.cs" />
     <Compile Include="Hardware\IControl.cs" />
     <Compile Include="Hardware\IOControlCode.cs" />
     <Compile Include="Hardware\Computer.cs" />


### PR DESCRIPTION
Support for NVMe SSD. Should fix the SSD part of issue #963 (the mentioned Samsung SM951 is a NVMe SSD)

Tested on Win10 64-bit, SSD is an Intel SSD 750.
![ohm_nvme](https://cloud.githubusercontent.com/assets/29201518/26804471/5a66152c-4a48-11e7-9da6-42958121ccfa.png)
Part of the Report
> NVMeGeneric
> 
> Drive name: INTEL SSDPEDMW012T4
> Firmware version: 8EV10174
> 
> PCI Vendor ID: 0x8086
> IEEE OUI Identifier: 0x5cd2e4
> Total NVM Capacity: 0
> Unallocated NVM Capacity: 0
> Controller ID: 0
> Number of Namespaces: 1
> Namespace 1 Size: 1200243695616
> Namespace 1 Capacity: 1200243695616
> Namespace 1 Utilization: 1200243695616
> Namespace 1 LBA Data Size: 512
> Critical Warning: -
> Temperature: 34 Celsius
> Available Spare: 100%
> Available Spare Threshold: 10%
> Data Units Read: 21976904
> Data Units Written: 13212023
> Host Read Commands: 301480076
> Data Write Commands: 215624853
> Controller Busy Time: 0
> Power Cycles: 599
> Power On Hours: 4707
> Unsafe Shutdowns: 0
> Media Errors: 0
> Number of Error Information Log Entries: 0
> Warning Composite Temperature Time: 0
> Critical Composite Temperature Time: 0

I had to split AbstractHarddrive.cs into AbstractHarddrive and AbstractStorage classes, because NVMe doesn't fit the SMART model. AbstractStorage.CreateInstanstance will create AbstractHarddrive for SATA/ATA drives or NVMeGeneric for NVMe drives.