### PR TITLE
Add Gigabyte X79-UD3 rev 1.0 support (X79, IT8728F, socket 2011)

### DIFF
--- a/Hardware/Mainboard/Identification.cs
+++ b/Hardware/Mainboard/Identification.cs
@@ -180,6 +180,8 @@ namespace OpenHardwareMonitor.Hardware.Mainboard {
           return Model.X38_DS5;
         case "X58A-UD3R":
           return Model.X58A_UD3R;
+        case "X79-UD3":
+          return Model.X79_UD3;
         case "Z68A-D3H-B3":
           return Model.Z68A_D3H_B3;
         case "Z68AP-D3":

--- a/Hardware/Mainboard/Model.cs
+++ b/Hardware/Mainboard/Model.cs
@@ -75,6 +75,7 @@ namespace OpenHardwareMonitor.Hardware.Mainboard {
     P8Z68_V_PRO,
     X38_DS5,
     X58A_UD3R,
+    X79_UD3,
     Z68A_D3H_B3,
     Z68AP_D3,
     Z68X_UD3H_B3,

--- a/Hardware/Mainboard/SuperIOHardware.cs
+++ b/Hardware/Mainboard/SuperIOHardware.cs
@@ -831,6 +831,24 @@ namespace OpenHardwareMonitor.Hardware.Mainboard {
               f.Add(new Fan("System Fan #2", 3));
               f.Add(new Fan("System Fan #3", 4));
               break;
+            case Model.X79_UD3: // IT8728F
+              v.Add(new Voltage("VTT", 0));
+              v.Add(new Voltage("DIMM CH A/B", 1));
+              v.Add(new Voltage("+12V", 2, 10, 2));
+              v.Add(new Voltage("+5V", 3, 15, 10));
+              v.Add(new Voltage("VIN4", 4));
+              v.Add(new Voltage("VCore", 5));
+              v.Add(new Voltage("DIMM CH C/D", 6));
+              v.Add(new Voltage("+3V Standby", 7));
+              v.Add(new Voltage("VBat", 8, 1, 1));
+              t.Add(new Temperature("System", 0));
+              t.Add(new Temperature("CPU", 1));
+              t.Add(new Temperature("Northbridge", 2));
+              f.Add(new Fan("CPU Fan", 0));
+              f.Add(new Fan("System Fan #1", 1));
+              f.Add(new Fan("System Fan #2", 2));
+              f.Add(new Fan("System Fan #3", 3));
+              break;
             default:
               v.Add(new Voltage("Voltage #1", 0, true));
               v.Add(new Voltage("Voltage #2", 1, true));

--- a/Hardware/Mainboard/SuperIOHardware.cs
+++ b/Hardware/Mainboard/SuperIOHardware.cs
@@ -831,11 +831,7 @@ namespace OpenHardwareMonitor.Hardware.Mainboard {
               f.Add(new Fan("System Fan #2", 3));
               f.Add(new Fan("System Fan #3", 4));
               break;
-<<<<<<< HEAD
             case Model.X79_UD3: // IT8728F
-=======
-            case Model.X79_UD3: // IT8720F
->>>>>>> 27d85a7f5781ffa68253858f0a3df0f5f8857432
               v.Add(new Voltage("VTT", 0));
               v.Add(new Voltage("DIMM CH A/B", 1));
               v.Add(new Voltage("+12V", 2, 10, 2));


### PR DESCRIPTION
Hi,

I've added the support of the Gigabyte X79-UD3 Rev V1.0 (and no V1.1) motherboard.

The voltages and temperatures seems to be good now for this motherboard.

Regards.