### PR TITLE
Added support for Intel Core X (Skylake-X) CPUs.

### DIFF
--- a/Hardware/CPU/IntelCPU.cs
+++ b/Hardware/CPU/IntelCPU.cs
@@ -170,6 +170,7 @@ namespace OpenHardwareMonitor.Hardware.CPU {
                 break;
               case 0x4E:
               case 0x5E: // Intel Core i5, i7 6xxxx LGA1151 (14nm)
+              case 0x55: // Intel Core X i7, i9 7xxx LGA2066 (14nm)
                 microarchitecture = Microarchitecture.Skylake;
                 tjMax = GetTjMaxFromMSR();
                 break;


### PR DESCRIPTION
Tested with i7-7820X on ASUS Prime X299-Deluxe.

![proof.png](https://x.ezl.re/20170724_201117.png)

The power readouts broke after a BIOS/UEFI update (they're broken in all monitoring programs I tested), so I believe this is an unrelated issue to this patch.