### PR TITLE
Fixing crash caused by trying to log when log file is locked

### DIFF
--- a/GUI/MainForm.cs
+++ b/GUI/MainForm.cs
@@ -567,8 +567,16 @@ namespace OpenHardwareMonitor.GUI {
         wmiProvider.Update();
 
 
-      if (logSensors != null && logSensors.Value && delayCount >= 4)
-        logger.Log();
+      if (logSensors != null && logSensors.Value && delayCount >= 4) {
+        var result = logger.Log();
+        
+        if (result == Logger.Status.FileLocked) {
+          logSensors.Value = false;
+          MessageBox.Show("The log file is not writeable. " +
+              "Logging has been disabled.",
+              "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+        }
+      }
 
       if (delayCount < 4)
         delayCount++;

--- a/Utilities/Logger.cs
+++ b/Utilities/Logger.cs
@@ -17,6 +17,8 @@ using OpenHardwareMonitor.Hardware;
 
 namespace OpenHardwareMonitor.Utilities {
   public class Logger {
+    // status of logger after writing to log file
+    public enum Status { Success, Wait, FileLocked };
 
     private const string fileNameFormat = 
       "OpenHardwareMonitorLog-{0:yyyy-MM-dd}.csv";
@@ -113,15 +115,15 @@ namespace OpenHardwareMonitor.Utilities {
     }
 
     private void CreateNewLogFile() {
-      IList<ISensor> list = new List<ISensor>();
-      SensorVisitor visitor = new SensorVisitor(sensor => {
-        list.Add(sensor);
-      });
-      visitor.VisitComputer(computer);
-      sensors = list.ToArray();
-      identifiers = sensors.Select(s => s.Identifier.ToString()).ToArray();
-
       using (StreamWriter writer = new StreamWriter(fileName, false)) {
+        IList<ISensor> list = new List<ISensor>();
+        SensorVisitor visitor = new SensorVisitor(sensor => {
+          list.Add(sensor);
+        });
+        visitor.VisitComputer(computer);
+        sensors = list.ToArray();
+        identifiers = sensors.Select(s => s.Identifier.ToString()).ToArray();
+
         writer.Write(",");
         for (int i = 0; i < sensors.Length; i++) {
           writer.Write(sensors[i].Identifier);
@@ -146,18 +148,24 @@ namespace OpenHardwareMonitor.Utilities {
 
     public TimeSpan LoggingInterval { get; set; }
 
-    public void Log() {      
+    public Status Log() {  
       var now = DateTime.Now;
 
       if (lastLoggedTime + LoggingInterval - new TimeSpan(5000000) > now)
-        return;      
+        return Status.Wait;
 
       if (day != now.Date || !File.Exists(fileName)) {
         day = now.Date;
-        fileName = GetFileName(day);
+        fileName = GetFileName(now.Date);
 
-        if (!OpenExistingLogFile())
-          CreateNewLogFile();
+        if (!OpenExistingLogFile()) {
+          try {
+            CreateNewLogFile();
+          } catch (IOException) { 
+            day = DateTime.MinValue;
+            return Status.FileLocked;
+          }
+        }
       }
 
       try {
@@ -178,9 +186,12 @@ namespace OpenHardwareMonitor.Utilities {
               writer.WriteLine();
           }
         }
-      } catch (IOException) { }
+      } catch (IOException) {
+        return Status.FileLocked;
+      } catch { }
 
       lastLoggedTime = now;
+      return Status.Success;
     }
   }
 }


### PR DESCRIPTION
Adds a return value to Logger.Log() that gives info on the log attempt, and disables logging until re-enabled by the user if the file isn't writable.