### PR TITLE
Fix RDP system tray issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.suo
 /Bin
 /Obj
+/.vs

--- a/GUI/NotifyIconAdv.cs
+++ b/GUI/NotifyIconAdv.cs
@@ -525,31 +525,17 @@ namespace OpenHardwareMonitor.GUI {
 
           if (showNotifyIcon && icon != null) {
             if (!created) {
-              int i = 0;
-              do {
-                created = NativeMethods.Shell_NotifyIcon(
-                  NativeMethods.NotifyIconMessage.Add, data);
-                if (!created) {
-                  System.Threading.Thread.Sleep(200);
-                  i++;
-                }
-              } while (!created && i < 40);
+              NativeMethods.Shell_NotifyIcon(
+                NativeMethods.NotifyIconMessage.Add, data);
+              created = true;
             } else {
               NativeMethods.Shell_NotifyIcon(
                 NativeMethods.NotifyIconMessage.Modify, data);
             }
           } else {
             if (created) {
-              int i = 0;
-              bool deleted = false;
-              do {
-                deleted = NativeMethods.Shell_NotifyIcon(
-                  NativeMethods.NotifyIconMessage.Delete, data);
-                if (!deleted) {
-                  System.Threading.Thread.Sleep(200);
-                  i++;
-                }
-              } while (!deleted && i < 40);
+              NativeMethods.Shell_NotifyIcon(
+                NativeMethods.NotifyIconMessage.Delete, data);
               created = false;
             }
           }


### PR DESCRIPTION
Add .vs (Visual Studio caches/settings) to gitignore and attempted fix to RDP system tray issues referenced by issue 1092

The issue originally is that we were listening to WM_TASKBARCREATED and invalidating the system tray icon and trying to recreate it (see line 657). This makes sense if the taskbar is actually being recreated while the process is running, like if explorer restarts. But is unnecessary for RDP sessions.

Because created is false at the beginning of this method from our taskbarcreated invalidation, and because Shell_NotifyIcon(Add) fails because the icon already exists, we get stuck in an infinite sleep cycle on the UI thread. This not only prevents the system tray icon from updating but causes the main UI to hang as well.

This change puts us more in line with Microsoft's implementation, which I suspect OHM pulled from originally since the code looks nearly identical. This will work for cases where we really do need to add the tray icon, because Shell_NotifyIcon(Add) will succeed, and for cases where we only think we need to add the tray icon, because Shell_NotifyIcon(Add) will fail but we'll set created = true anyways. From the documentation on this method I couldnt find any situations where Shell_NotifyIcon(Add) would fail unless it already exists.
https://referencesource.microsoft.com/#System.Windows.Forms/winforms/Managed/System/WinForms/NotifyIcon.cs,791

Note; This is actually not only my first contribution to an open source project, but first git pull request ever since we use TFS at work :P