### PR TITLE
Added experimental support for the chip ITE IT8686E.

### DIFF
--- a/Hardware/LPC/Chip.cs
+++ b/Hardware/LPC/Chip.cs
@@ -27,6 +27,7 @@ namespace OpenHardwareMonitor.Hardware.LPC {
 
     IT8620E = 0x8620,
     IT8628E = 0x8628,
+    IT8686E = 0x8686,
     IT8705F = 0x8705,
     IT8712F = 0x8712,
     IT8716F = 0x8716,
@@ -74,6 +75,7 @@ namespace OpenHardwareMonitor.Hardware.LPC {
 
         case Chip.IT8620E: return "ITE IT8620E";
         case Chip.IT8628E: return "ITE IT8628E";
+        case Chip.IT8686E: return "ITE IT8686E";
         case Chip.IT8705F: return "ITE IT8705F";
         case Chip.IT8712F: return "ITE IT8712F";
         case Chip.IT8716F: return "ITE IT8716F";

--- a/Hardware/LPC/IT87XX.cs
+++ b/Hardware/LPC/IT87XX.cs
@@ -139,14 +139,15 @@ namespace OpenHardwareMonitor.Hardware.LPC {
         return;
 
       voltages = new float?[9];
-      temperatures = new float?[3];
+      temperatures = new float?[chip == Chip.IT8686E ? 6 : 3];
       fans = new float?[chip == Chip.IT8705F ? 3 : 5];
       controls = new float?[3];
 
       // IT8620E, IT8628E, IT8721F, IT8728F and IT8772E use a 12mV resultion 
       // ADC, all others 16mV
       if (chip == Chip.IT8620E || chip == Chip.IT8628E || chip == Chip.IT8721F 
-        || chip == Chip.IT8728F || chip == Chip.IT8771E || chip == Chip.IT8772E) 
+        || chip == Chip.IT8728F || chip == Chip.IT8771E || chip == Chip.IT8772E
+        || chip == Chip.IT8686E ) 
       {
         voltageGain = 0.012f;
       } else {
@@ -180,6 +181,12 @@ namespace OpenHardwareMonitor.Hardware.LPC {
         case Chip.IT8728F:
         case Chip.IT8771E:
         case Chip.IT8772E:
+          gpioCount = 0;
+          break;
+        case Chip.IT8686E:
+          // This is probably wrong number of GPIO. I don't have access to a datasheet
+          // for the IT8686E chip so I'm unable to determine the number of GPIO.
+          // Thus setting it to 0 to avoid any other part of the code trying to read from GPIO
           gpioCount = 0;
           break;
       }

--- a/Hardware/LPC/LPCIO.cs
+++ b/Hardware/LPC/LPCIO.cs
@@ -333,6 +333,7 @@ namespace OpenHardwareMonitor.Hardware.LPC {
       switch (chipID) {
         case 0x8620: chip = Chip.IT8620E; break;
         case 0x8628: chip = Chip.IT8628E; break;
+        case 0x8686: chip = Chip.IT8686E; break;
         case 0x8705: chip = Chip.IT8705F; break;
         case 0x8712: chip = Chip.IT8712F; break;
         case 0x8716: chip = Chip.IT8716F; break;


### PR DESCRIPTION
This chip is used in for example the Gigabyte Z370N WiFi motherboard.
Support for Temperature and Fan RPM verified on a Gigabyte Z370N WiFi motherboard.
GPIO reading not impleneted due to lack of access to original datasheet for IT8686E.