### PR TITLE
fix gadget not hide in "fullscreen"/borderless mode

### DIFF
--- a/GUI/GadgetWindow.cs
+++ b/GUI/GadgetWindow.cs
@@ -58,9 +58,20 @@ namespace OpenHardwareMonitor.GUI {
 
     private void ShowDesktopChanged(bool showDesktop) {
       if (showDesktop) {
-        MoveToTopMost(Handle);
-      } else {
-        MoveToBottom(Handle);
+        if (alwaysOnTop) {
+          MoveToTopMost(Handle);
+        }
+        else {
+          MoveToBottom(Handle);
+        }
+      }
+      else {
+        if (alwaysOnTop) {
+          MoveToBottom(Handle);
+        }
+        else {
+          MoveToTopMost(Handle);
+        }
       }
     }
 
@@ -284,17 +295,17 @@ namespace OpenHardwareMonitor.GUI {
       get {
         return visible;
       }
-      set {
+      set {//only call once in option change
         if (visible != value) {
           visible = value;
           NativeMethods.SetWindowPos(Handle, IntPtr.Zero, 0, 0, 0, 0,
             SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOZORDER |
             (value ? SWP_SHOWWINDOW : SWP_HIDEWINDOW));
           if (value) {
-            if (!alwaysOnTop)
+            //if (!alwaysOnTop)
               ShowDesktop.Instance.ShowDesktopChanged += ShowDesktopChanged;
           } else {
-            if (!alwaysOnTop)
+            //if (!alwaysOnTop)
               ShowDesktop.Instance.ShowDesktopChanged -= ShowDesktopChanged;
           }
         }
@@ -319,13 +330,13 @@ namespace OpenHardwareMonitor.GUI {
         if (value != alwaysOnTop) {
           alwaysOnTop = value;
           if (alwaysOnTop) {
-            if (visible)
-              ShowDesktop.Instance.ShowDesktopChanged -= ShowDesktopChanged;
+            //if (visible)
+             // ShowDesktop.Instance.ShowDesktopChanged -= ShowDesktopChanged;
             MoveToTopMost(Handle);            
           } else {
             MoveToBottom(Handle);
-            if (visible)
-              ShowDesktop.Instance.ShowDesktopChanged += ShowDesktopChanged;
+            //if (visible)
+              //ShowDesktop.Instance.ShowDesktopChanged += ShowDesktopChanged;
           }
         }
       }


### PR DESCRIPTION
I found that the gadget won't hide when a "fullscreen" or borderless application is showing in foreground. It really bothers when watching video or playing games. So the expected operation is to hide gadget when a "fullscreen" foreground application is running

I'm not sure whether [these codes](https://github.com/openhardwaremonitor/openhardwaremonitor/blob/master/GUI/ShowDesktop.cs#L87-L96) contain that function, but I found it not working, so i just comment it and write some new.
