### PR TITLE
Set C# language version to 7.3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+ <PropertyGroup>
+   <LangVersion>7.3</LangVersion>
+ </PropertyGroup>
+</Project>


### PR DESCRIPTION
This file sets the language version to C# 7.3 for all projects in subdirectories. Please see [docs for more info](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version#configure-multiple-projects).

Without this, the solution does not build on Visual Studio 2017. This is because by default VS uses latest major language version, which for VS 2017 is C# 7.0. However, there is one C# 7.3 feature being used:

> Error    CS8107    Feature 'delegate generic type constraints' is not available in C# 7.0. Please use language version 7.3 or greater.    OpenHardwareMonitorLib    C:\Dev\openhardwaremonitor\Hardware\Nvidia\NVML.cs    71    Active

Another option would be to set `<LangVersion>7.3</LangVersion>` for all .csproj files.
