### PR TITLE
Save splitter position (plotpanel)

### DIFF
--- a/GUI/MainForm.cs
+++ b/GUI/MainForm.cs
@@ -578,6 +578,7 @@ namespace OpenHardwareMonitor.GUI {
         return;
 
       if (plotPanel != null) {
+        settings.SetValue("splitContainer.SplitterDistance", splitContainer.SplitterDistance);
         plotPanel.SetCurrentSettings();
         foreach (TreeColumn column in treeView.Columns)
           settings.SetValue("treeView.Columns." + column.Header + ".Width",
@@ -629,6 +630,9 @@ namespace OpenHardwareMonitor.GUI {
       }
 
       this.Bounds = newBounds;
+
+      if (!splitContainer.Panel2Collapsed)
+        splitContainer.SplitterDistance = settings.GetValue("splitContainer.SplitterDistance", splitContainer.SplitterDistance);
     }
     
     private void MainForm_FormClosed(object sender, FormClosedEventArgs e) {


### PR DESCRIPTION
If plotwindow is docked in mainform, splitter position should be saved.