### PR TITLE
Gigabyte GA-Z68XP-UD3R support

### DIFF
--- a/Hardware/Mainboard/Identification.cs
+++ b/Hardware/Mainboard/Identification.cs
@@ -282,6 +282,8 @@ namespace OpenHardwareMonitor.Hardware.Mainboard {
           return Model.Z68X_UD3H_B3;
         case "Z68X-UD7-B3":
           return Model.Z68X_UD7_B3;
+        case "Z68XP-UD3R":
+          return Model.Z68XP_UD3R;
         case "Z390 M GAMING-CF":
           return Model.Z390_M_GAMING;
         case "Z390 AORUS ULTRA":

--- a/Hardware/Mainboard/Model.cs
+++ b/Hardware/Mainboard/Model.cs
@@ -80,6 +80,7 @@ namespace OpenHardwareMonitor.Hardware.Mainboard {
     Z68AP_D3,
     Z68X_UD3H_B3,
     Z68X_UD7_B3,
+    Z68XP_UD3R,
     Z390_M_GAMING,
     Z390_AORUS_ULTRA,
     Z390_UD,

--- a/Hardware/Mainboard/SuperIOHardware.cs
+++ b/Hardware/Mainboard/SuperIOHardware.cs
@@ -864,6 +864,7 @@ namespace OpenHardwareMonitor.Hardware.Mainboard {
             case Model.P67A_UD4_B3: // IT8728F                
             case Model.Z68AP_D3: // IT8728F
             case Model.Z68X_UD3H_B3: // IT8728F               
+            case Model.Z68XP_UD3R: // IT8728F
               v.Add(new Voltage("VTT", 0));
               v.Add(new Voltage("+3.3V", 1, 6.49f, 10));
               v.Add(new Voltage("+12V", 2, 30.9f, 10));


### PR DESCRIPTION
Added the Gigabyte Z68XP-UD3R to SuperIOHardware.cs giving all items correct labels. Verified by comparing with the BIOS readouts for the named items. 
![Annotation 2020-06-10 212104](https://user-images.githubusercontent.com/19158781/84262480-0ad30380-ab61-11ea-868d-2d488109d36b.png)
