### PR TITLE
Z390 Aorus Ultra Identification fix

### DIFF
--- a/Hardware/Mainboard/Identification.cs
+++ b/Hardware/Mainboard/Identification.cs
@@ -285,6 +285,7 @@ namespace OpenHardwareMonitor.Hardware.Mainboard {
         case "Z390 M GAMING-CF":
           return Model.Z390_M_GAMING;
         case "Z390 AORUS ULTRA":
+        case "Z390 AORUS ULTRA-CF":
           return Model.Z390_AORUS_ULTRA;
         case "Z390 UD":
           return Model.Z390_UD;


### PR DESCRIPTION
The model is has the prefix "-CF" on the name for some users.