### PR TITLE
Closes #1432

### DIFF
--- a/Hardware/Sensor.cs
+++ b/Hardware/Sensor.cs
@@ -96,28 +96,30 @@ namespace OpenHardwareMonitor.Hardware {
       string name = new Identifier(Identifier, "values").ToString();
       string s = settings.GetValue(name, null);
 
-      try {
-        byte[] array = Convert.FromBase64String(s);
-        s = null;
-        DateTime now = DateTime.UtcNow;
-        using (MemoryStream m = new MemoryStream(array))
-        using (GZipStream c = new GZipStream(m, CompressionMode.Decompress))
-        using (BinaryReader reader = new BinaryReader(c)) {
-          try {
-            long t = 0;
-            while (true) {
-              t += reader.ReadInt64();
-              DateTime time = DateTime.FromBinary(t);
-              if (time > now)
-                break;
-              float value = reader.ReadSingle();
-              AppendValue(value, time);
-            }
-          } catch (EndOfStreamException) { }
-        }
-      } catch { }
-      if (values.Count > 0)
-        AppendValue(float.NaN, DateTime.UtcNow);
+      if (s != null) {
+        try {
+          byte[] array = Convert.FromBase64String(s);
+          s = null;
+          DateTime now = DateTime.UtcNow;
+          using (MemoryStream m = new MemoryStream(array))
+          using (GZipStream c = new GZipStream(m, CompressionMode.Decompress))
+          using (BinaryReader reader = new BinaryReader(c)) {
+            try {
+              long t = 0;
+              while (true) {
+                t += reader.ReadInt64();
+                DateTime time = DateTime.FromBinary(t);
+                if (time > now)
+                  break;
+                float value = reader.ReadSingle();
+                AppendValue(value, time);
+              }
+            } catch (EndOfStreamException) { }
+          }
+        } catch { }
+        if (values.Count > 0)
+          AppendValue(float.NaN, DateTime.UtcNow);
+      }
 
       // remove the value string from the settings to reduce memory usage
       settings.Remove(name);


### PR DESCRIPTION
- Add null check for the string input to method `Convert.FromBase64String()`.
- Ensure the function is still removing "...the value string from the settings to reduce memory usage"