### PR TITLE
MainForm: persist splitContainer SplitterDistance

### DIFF
--- a/GUI/MainForm.cs
+++ b/GUI/MainForm.cs
@@ -650,6 +650,23 @@ namespace OpenHardwareMonitor.GUI {
       }
 
       this.Bounds = newBounds;
+
+      // This setting needs to be applied after the form load since it otherwise triggers
+      // a relayout.
+      if (this.settings.Contains("splitContainer.SplitterDistance")) {
+        this.splitContainer.SplitterDistance = this.settings.GetValue("splitContainer.SplitterDistance", 0);
+      }
+
+      // This event needs to be attached after the form load since it otherwise
+      // triggers a relayout.
+      this.splitContainer.SplitterMoved += delegate (object splitterSender,
+		      SplitterEventArgs splitterEvent) {
+        if (this.settings.GetValue("plotLocation", 0) == 1) {
+          this.settings.SetValue("splitContainer.SplitterDistance", splitterEvent.SplitY);
+        } else if (this.settings.GetValue("plotLocation", 0) == 2) {
+          this.settings.SetValue("splitContainer.SplitterDistance", splitterEvent.SplitX);
+        }
+      };
     }
     
     private void MainForm_FormClosed(object sender, FormClosedEventArgs e) {


### PR DESCRIPTION
The application of the persistent setting and the hooking up of the
'SplitterMoved' event is done after the 'MainForm' load event since that
can trigger a relayout.