### PR TITLE
HttpServer: only stop a running server

### DIFF
--- a/Utilities/HttpServer.cs
+++ b/Utilities/HttpServer.cs
@@ -77,6 +77,9 @@ namespace OpenHardwareMonitor.Utilities {
       if (PlatformNotSupported)
         return false;
 
+      if (listenerThread == null)
+        return false;
+
       try {
         listenerThread.Abort();
         listener.Stop();


### PR DESCRIPTION
Check if the server is running before trying to stop it since
'StopHTTPListener' is called even if the server may not be running.

This otherwise triggers an exception that makes it difficult to
run the application in Debug mode.