### PR TITLE
Add support for the Gigabyte B360 AORUS GAMING 3 WIFI-CF mainboard.

### DIFF
--- a/Hardware/Mainboard/Identification.cs
+++ b/Hardware/Mainboard/Identification.cs
@@ -166,6 +166,8 @@ namespace OpenHardwareMonitor.Hardware.Mainboard {
 
     public static Model GetModel(string name) {
       switch (name) {
+        case "B360 AORUS GAMING 3 WIFI-CF":
+          return Model.B360_AORUS_GAMING_3_WIFI_CF;
         case "880GMH/USB3":
           return Model._880GMH_USB3;
         case "ASRock AOD790GX/128M":

--- a/Hardware/Mainboard/Model.cs
+++ b/Hardware/Mainboard/Model.cs
@@ -83,6 +83,7 @@ namespace OpenHardwareMonitor.Hardware.Mainboard {
     Z390_M_GAMING,
     Z390_AORUS_ULTRA,
     Z390_UD,
+    B360_AORUS_GAMING_3_WIFI_CF,
 
     // Shuttle
     FH67,

--- a/Hardware/Mainboard/SuperIOHardware.cs
+++ b/Hardware/Mainboard/SuperIOHardware.cs
@@ -822,6 +822,7 @@ namespace OpenHardwareMonitor.Hardware.Mainboard {
               break;
             case Model.Z390_M_GAMING: // IT8688E
             case Model.Z390_AORUS_ULTRA:
+            case Model.B360_AORUS_GAMING_3_WIFI_CF:
             case Model.Z390_UD:
               v.Add(new Voltage("CPU VCore", 0));
               v.Add(new Voltage("+3.3V", 1, 6.49f, 10));


### PR DESCRIPTION
This mainboard uses the IT8686E controller, and it only needed to be
added to the list. Should close #1488.