### PR TITLE
Ignore temperature updates if the sensor is NONE

### DIFF
--- a/Hardware/Nvidia/NvidiaGPU.cs
+++ b/Hardware/Nvidia/NvidiaGPU.cs
@@ -182,8 +182,12 @@ namespace OpenHardwareMonitor.Hardware.Nvidia {
 
     public override void Update() {
       NvGPUThermalSettings settings = GetThermalSettings();
-      foreach (Sensor sensor in temperatures)
-        sensor.Value = settings.Sensor[sensor.Index].CurrentTemp;
+      foreach (Sensor sensor in temperatures) {
+        NvSensor nvSensor = settings.Sensor[sensor.Index];
+        if (nvSensor.Controller == NvThermalController.NONE)
+          continue;
+        sensor.Value = nvSensor.CurrentTemp;
+      }
 
       bool tachReadingOk = false;
       if (NVAPI.NvAPI_GPU_GetTachReading != null && 


### PR DESCRIPTION
This commit adds a condition to skip updating the sensor value if the other fields are not valid.

For whatever reason the temperature is coming back as 0 at times.  When this happens the controller is also reported as NONE, the min==max==0, and the Target is also NONE.  (Only the first condition is checked)

https://github.com/openhardwaremonitor/openhardwaremonitor/issues/1587