### PR TITLE
AMD17CPU missing Update();

### DIFF
--- a/Hardware/CPU/AMD17CPU.cs
+++ b/Hardware/CPU/AMD17CPU.cs
@@ -135,6 +135,8 @@ namespace OpenHardwareMonitor.Hardware.CPU {
       for (int i = 0; i < this.cores.Length; i++) {
         this.cores[i] = new Core(i, cpuid[i], this, settings);
       }
+
+      Update();   
     }
 
     protected override uint[] GetMSRs() {


### PR DESCRIPTION
When using OpenHardwareMonitorLib via Powershell on a AMD17CPU computer, $Computer.Hardware.Sensors returns null values but returns current values for other CPU types. AMD17CPU was missing an Update() call in the constructor.